### PR TITLE
Add deterministic integer-only xorshift32 RNG module

### DIFF
--- a/engine/rng/xorshift32.ts
+++ b/engine/rng/xorshift32.ts
@@ -1,0 +1,35 @@
+export class XorShift32 {
+  private state: number;
+
+  constructor(seed: number) {
+    const normalizedSeed = seed | 0;
+    this.state = normalizedSeed === 0 ? 1 : normalizedSeed;
+  }
+
+  nextU32(): number {
+    let x = this.state | 0;
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    this.state = x | 0;
+    return this.state >>> 0;
+  }
+
+  nextInt(minInclusive: number, maxInclusive: number): number {
+    if (!Number.isInteger(minInclusive) || !Number.isInteger(maxInclusive)) {
+      throw new Error('nextInt bounds must be integers');
+    }
+
+    if (maxInclusive < minInclusive) {
+      throw new Error('maxInclusive must be >= minInclusive');
+    }
+
+    const span = maxInclusive - minInclusive + 1;
+    if (span <= 0) {
+      throw new Error('Range size must be positive');
+    }
+
+    const value = this.nextU32() % span;
+    return minInclusive + value;
+  }
+}

--- a/tests/rng.test.ts
+++ b/tests/rng.test.ts
@@ -1,0 +1,40 @@
+import { XorShift32 } from '../engine/rng/xorshift32';
+
+describe('XorShift32', () => {
+  it('produces the same sequence for the same seed', () => {
+    const a = new XorShift32(123456);
+    const b = new XorShift32(123456);
+
+    const seqA = Array.from({ length: 10 }, () => a.nextU32());
+    const seqB = Array.from({ length: 10 }, () => b.nextU32());
+
+    expect(seqA).toEqual(seqB);
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const a = new XorShift32(123456);
+    const b = new XorShift32(654321);
+
+    const seqA = Array.from({ length: 10 }, () => a.nextU32());
+    const seqB = Array.from({ length: 10 }, () => b.nextU32());
+
+    expect(seqA).not.toEqual(seqB);
+  });
+
+  it('respects inclusive bounds in nextInt', () => {
+    const rng = new XorShift32(42);
+
+    for (let i = 0; i < 1000; i += 1) {
+      const n = rng.nextInt(1, 10000);
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(10000);
+    }
+  });
+
+  it('coerces seed 0 to 1 deterministically', () => {
+    const zeroSeed = new XorShift32(0);
+    const oneSeed = new XorShift32(1);
+
+    expect(zeroSeed.nextU32()).toBe(oneSeed.nextU32());
+  });
+});


### PR DESCRIPTION
### Motivation
- The SSOT requires a deterministic, integer-only RNG (`xorshift32`) for all combat randomness to ensure reproducible simulations and server-side determinism.
- The RNG must be seeded, reproducible, and avoid floating-point operations in the output path.

### Description
- Add `engine/rng/xorshift32.ts` implementing `XorShift32` with seed normalization (coerce `0` to `1`) and integer-only state updates.
- Implement `nextU32()` that performs xorshift32 bitwise steps and returns an unsigned 32-bit integer, and `nextInt(minInclusive, maxInclusive)` that returns an inclusive integer in range using modular arithmetic.
- Validate integer bounds in `nextInt()` and throw on invalid inputs, and avoid any floating-point math in RNG methods.
- Add `tests/rng.test.ts` with tests for same-seed determinism, different-seed divergence, inclusive bounds behavior, and zero-seed coercion.

### Testing
- Ran `npm test` which initially failed with `jest: not found` before dependencies were installed.
- Ran `npm ci` to install dependencies and then ran `npm test` which passed all suites.
- Test results: `PASS tests/rng.test.ts` and `PASS tests/smoke.test.ts` (2 test suites, 5 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9307d7b9083299f6bf30977459ce7)