### PR TITLE
Add shared combat and battle replay TypeScript contracts

### DIFF
--- a/types/battle.ts
+++ b/types/battle.ts
@@ -1,0 +1,85 @@
+import type { CombatantSnapshot } from "./combat";
+
+export type BattleEvent =
+  | {
+      type: "ROUND_START";
+      round: number;
+    }
+  | {
+      type: "ACTION";
+      round: number;
+      actorEntityId: number;
+      targetEntityId: number;
+      skillId: string;
+    }
+  | {
+      type: "HIT_RESULT";
+      round: number;
+      actorEntityId: number;
+      targetEntityId: number;
+      skillId: string;
+      roll: number;
+      hitChanceBP: number;
+      didHit: boolean;
+    }
+  | {
+      type: "DAMAGE";
+      round: number;
+      actorEntityId: number;
+      targetEntityId: number;
+      skillId: string;
+      amount: number;
+      targetHpAfter: number;
+    }
+  | {
+      type: "STATUS_APPLY";
+      round: number;
+      targetEntityId: number;
+      statusId: string;
+      sourceEntityId: number;
+      remainingTurns: number;
+    }
+  | {
+      type: "STATUS_REFRESH";
+      round: number;
+      targetEntityId: number;
+      statusId: string;
+      sourceEntityId: number;
+      remainingTurns: number;
+    }
+  | {
+      type: "STATUS_EXPIRE";
+      round: number;
+      targetEntityId: number;
+      statusId: string;
+    }
+  | {
+      type: "COOLDOWN_SET";
+      round: number;
+      actorEntityId: number;
+      skillId: string;
+      cooldownRemainingTurns: number;
+    }
+  | {
+      type: "ROUND_END";
+      round: number;
+    }
+  | {
+      type: "DEATH";
+      round: number;
+      targetEntityId: number;
+    }
+  | {
+      type: "BATTLE_END";
+      round: number;
+      winnerEntityId: number;
+      loserEntityId: number;
+    };
+
+export interface BattleResult {
+  battleId: string;
+  seed: number;
+  playerInitial: CombatantSnapshot;
+  enemyInitial: CombatantSnapshot;
+  events: BattleEvent[];
+}

--- a/types/combat.ts
+++ b/types/combat.ts
@@ -1,0 +1,44 @@
+export type EntitySide = "PLAYER" | "ENEMY";
+
+export interface CombatantSnapshot {
+  entityId: number;
+  side: EntitySide;
+  name: string;
+  hp: number;
+  hpMax: number;
+  atk: number;
+  def: number;
+  spd: number;
+  initiative: number;
+  accuracyBP: number;
+  evadeBP: number;
+}
+
+export interface StatusDef {
+  id: string;
+  name: string;
+  durationTurns: number;
+  tags: string[];
+}
+
+export interface ActiveStatus {
+  statusId: string;
+  sourceEntityId: number;
+  remainingTurns: number;
+}
+
+export interface SkillDef {
+  id: string;
+  name: string;
+  cooldownTurns: number;
+  basePower: number;
+  accuracyModBP: number;
+  tags: string[];
+  statusEffects: StatusDef[];
+}
+
+export interface SkillLoadout {
+  basicAttack: SkillDef;
+  activeSkill1: SkillDef;
+  activeSkill2: SkillDef;
+}


### PR DESCRIPTION
### Motivation
- Provide a canonical TypeScript contract shared between server and client for the deterministic turn-based combat system. 
- Ensure all combat data uses integer-only values (basis points for accuracy/evasion) to comply with the SSOT determinism rules. 
- Define a deterministic, replayable event log shape so the server can return a full replay `BattleResult` that the client can deterministically replay.

### Description
- Added `types/combat.ts` which exports `CombatantSnapshot`, `SkillDef`, `StatusDef`, `ActiveStatus`, `SkillLoadout`, and `EntitySide` to describe combatants and loadouts. 
- Added `types/battle.ts` which exports the `BattleEvent` discriminated union covering `ROUND_START`, `ACTION`, `HIT_RESULT`, `DAMAGE`, `STATUS_APPLY`, `STATUS_REFRESH`, `STATUS_EXPIRE`, `COOLDOWN_SET`, `ROUND_END`, `DEATH`, and `BATTLE_END`, plus `BattleResult` with `{ battleId, seed, playerInitial, enemyInitial, events }`. 
- All numeric fields are integers and accuracy/evasion use basis points (`accuracyBP` / `evadeBP`).

### Testing
- Ran `npm ci` to install dependencies and then `npm run build`, and the build completed successfully (type checking and static build passed). 
- TypeScript compile was performed under `strict: true` as configured in `tsconfig.json`, and the new types compile without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a932c42ec4832989f076765f940b30)