### PR TITLE
Implement WO3 deterministic battle engine v0

### DIFF
--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -1,0 +1,153 @@
+import { applyRoundInitiative, hasReadyActor, nextActorIndex, timeoutWinner } from './initiative';
+import { resolveAttack } from './resolveDamage';
+import { XorShift32 } from '../rng/xorshift32';
+
+export type BattleEntity = {
+  entityId: string;
+  hp: number;
+  atk: number;
+  def: number;
+  spd: number;
+  accuracyBP: number;
+  evadeBP: number;
+};
+
+export type BattleInput = {
+  battleId: string;
+  seed: number;
+  playerInitial: BattleEntity;
+  enemyInitial: BattleEntity;
+  maxRounds?: number;
+};
+
+export type BattleEvent =
+  | { type: 'ROUND_START'; round: number }
+  | { type: 'ACTION'; round: number; actorId: string; targetId: string; skillId: 'BASIC_ATTACK' }
+  | { type: 'HIT_RESULT'; round: number; actorId: string; targetId: string; hitChanceBP: number; rollBP: number; didHit: boolean }
+  | { type: 'DAMAGE'; round: number; actorId: string; targetId: string; amount: number; targetHpAfter: number }
+  | { type: 'DEATH'; round: number; entityId: string }
+  | { type: 'ROUND_END'; round: number }
+  | { type: 'BATTLE_END'; round: number; winnerEntityId: string; reason: 'death' | 'timeout' };
+
+export type BattleResult = {
+  battleId: string;
+  seed: number;
+  playerInitial: BattleEntity;
+  enemyInitial: BattleEntity;
+  events: BattleEvent[];
+  winnerEntityId: string;
+  roundsPlayed: number;
+};
+
+type RuntimeEntity = BattleEntity & { initiative: number };
+
+const BASIC_ATTACK = {
+  skillId: 'BASIC_ATTACK' as const,
+  basePower: 100,
+  accuracyModBP: 0
+};
+
+function cloneEntity(entity: BattleEntity): BattleEntity {
+  return { ...entity };
+}
+
+export function simulateBattle(input: BattleInput): BattleResult {
+  const rng = new XorShift32(input.seed);
+  const maxRounds = input.maxRounds ?? 30;
+  const events: BattleEvent[] = [];
+
+  const player: RuntimeEntity = { ...cloneEntity(input.playerInitial), initiative: 0 };
+  const enemy: RuntimeEntity = { ...cloneEntity(input.enemyInitial), initiative: 0 };
+  const combatants: RuntimeEntity[] = [player, enemy];
+
+  let roundsPlayed = 0;
+  let winner: RuntimeEntity | null = null;
+  let reason: 'death' | 'timeout' = 'timeout';
+
+  for (let round = 1; round <= maxRounds; round += 1) {
+    roundsPlayed = round;
+    events.push({ type: 'ROUND_START', round });
+    applyRoundInitiative(combatants);
+
+    while (hasReadyActor(combatants)) {
+      const actorIndex = nextActorIndex(combatants);
+      if (actorIndex < 0) {
+        break;
+      }
+
+      const actor = combatants[actorIndex];
+      const target = combatants[1 - actorIndex];
+
+      if (actor.hp <= 0 || target.hp <= 0) {
+        break;
+      }
+
+      actor.initiative -= 100;
+      events.push({
+        type: 'ACTION',
+        round,
+        actorId: actor.entityId,
+        targetId: target.entityId,
+        skillId: 'BASIC_ATTACK'
+      });
+
+      const attack = resolveAttack(actor, target, BASIC_ATTACK, rng);
+      events.push({
+        type: 'HIT_RESULT',
+        round,
+        actorId: actor.entityId,
+        targetId: target.entityId,
+        hitChanceBP: attack.hitChanceBP,
+        rollBP: attack.rollBP,
+        didHit: attack.didHit
+      });
+
+      if (attack.didHit) {
+        target.hp = Math.max(0, target.hp - attack.damage);
+        events.push({
+          type: 'DAMAGE',
+          round,
+          actorId: actor.entityId,
+          targetId: target.entityId,
+          amount: attack.damage,
+          targetHpAfter: target.hp
+        });
+
+        if (target.hp === 0) {
+          events.push({ type: 'DEATH', round, entityId: target.entityId });
+          winner = actor;
+          reason = 'death';
+          break;
+        }
+      }
+    }
+
+    events.push({ type: 'ROUND_END', round });
+
+    if (winner !== null) {
+      break;
+    }
+  }
+
+  if (winner === null) {
+    winner = timeoutWinner(player, enemy) as RuntimeEntity;
+    reason = 'timeout';
+  }
+
+  events.push({
+    type: 'BATTLE_END',
+    round: roundsPlayed,
+    winnerEntityId: winner.entityId,
+    reason
+  });
+
+  return {
+    battleId: input.battleId,
+    seed: input.seed,
+    playerInitial: cloneEntity(input.playerInitial),
+    enemyInitial: cloneEntity(input.enemyInitial),
+    events,
+    winnerEntityId: winner.entityId,
+    roundsPlayed
+  };
+}

--- a/engine/battle/initiative.ts
+++ b/engine/battle/initiative.ts
@@ -1,0 +1,51 @@
+export type InitiativeCombatant = {
+  entityId: string;
+  spd: number;
+  initiative: number;
+  hp: number;
+};
+
+function compareTurnOrder(a: InitiativeCombatant, b: InitiativeCombatant): number {
+  if (a.initiative !== b.initiative) {
+    return b.initiative - a.initiative;
+  }
+
+  if (a.spd !== b.spd) {
+    return b.spd - a.spd;
+  }
+
+  return a.entityId.localeCompare(b.entityId);
+}
+
+export function applyRoundInitiative(combatants: InitiativeCombatant[]): void {
+  for (const combatant of combatants) {
+    if (combatant.hp > 0) {
+      combatant.initiative += combatant.spd;
+    }
+  }
+}
+
+export function hasReadyActor(combatants: InitiativeCombatant[]): boolean {
+  return combatants.some((combatant) => combatant.hp > 0 && combatant.initiative >= 100);
+}
+
+export function nextActorIndex(combatants: InitiativeCombatant[]): number {
+  const ordered = combatants
+    .map((combatant, index) => ({ combatant, index }))
+    .filter(({ combatant }) => combatant.hp > 0 && combatant.initiative >= 100)
+    .sort((left, right) => compareTurnOrder(left.combatant, right.combatant));
+
+  return ordered.length === 0 ? -1 : ordered[0].index;
+}
+
+export function timeoutWinner(a: InitiativeCombatant, b: InitiativeCombatant): InitiativeCombatant {
+  if (a.hp !== b.hp) {
+    return a.hp > b.hp ? a : b;
+  }
+
+  if (a.initiative !== b.initiative) {
+    return a.initiative > b.initiative ? a : b;
+  }
+
+  return a.entityId.localeCompare(b.entityId) <= 0 ? a : b;
+}

--- a/engine/battle/resolveDamage.ts
+++ b/engine/battle/resolveDamage.ts
@@ -1,0 +1,57 @@
+import { XorShift32 } from '../rng/xorshift32';
+
+export type AttackSnapshot = {
+  entityId: string;
+  atk: number;
+  def: number;
+  accuracyBP: number;
+  evadeBP: number;
+};
+
+export type AttackSkill = {
+  skillId: string;
+  basePower: number;
+  accuracyModBP: number;
+};
+
+export type AttackResolution = {
+  rollBP: number;
+  hitChanceBP: number;
+  didHit: boolean;
+  damage: number;
+};
+
+const MIN_HIT_BP = 500;
+const MAX_HIT_BP = 9500;
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function calculateHitChanceBP(actor: AttackSnapshot, target: AttackSnapshot, skill: AttackSkill): number {
+  return clamp(actor.accuracyBP - target.evadeBP + skill.accuracyModBP, MIN_HIT_BP, MAX_HIT_BP);
+}
+
+export function calculateDamage(actor: AttackSnapshot, target: AttackSnapshot, skill: AttackSkill): number {
+  const raw = skill.basePower + actor.atk;
+  const damage = Math.floor((raw * 100) / (100 + target.def));
+  return Math.max(1, damage);
+}
+
+export function resolveAttack(
+  actor: AttackSnapshot,
+  target: AttackSnapshot,
+  skill: AttackSkill,
+  rng: XorShift32
+): AttackResolution {
+  const hitChanceBP = calculateHitChanceBP(actor, target, skill);
+  const rollBP = rng.nextInt(1, 10000);
+  const didHit = rollBP <= hitChanceBP;
+
+  return {
+    rollBP,
+    hitChanceBP,
+    didHit,
+    damage: didHit ? calculateDamage(actor, target, skill) : 0
+  };
+}

--- a/tests/battleEngine.v0.test.ts
+++ b/tests/battleEngine.v0.test.ts
@@ -1,0 +1,89 @@
+import { simulateBattle, type BattleEntity } from '../engine/battle/battleEngine';
+
+function baseEntity(overrides: Partial<BattleEntity>): BattleEntity {
+  return {
+    entityId: 'entity',
+    hp: 2000,
+    atk: 150,
+    def: 120,
+    spd: 100,
+    accuracyBP: 8000,
+    evadeBP: 1500,
+    ...overrides
+  };
+}
+
+describe('battleEngine v0', () => {
+  it('is deterministic for same input and seed', () => {
+    const player = baseEntity({ entityId: 'player', spd: 120 });
+    const enemy = baseEntity({ entityId: 'enemy', spd: 110 });
+
+    const first = simulateBattle({
+      battleId: 'determinism',
+      seed: 12345,
+      playerInitial: player,
+      enemyInitial: enemy
+    });
+
+    const second = simulateBattle({
+      battleId: 'determinism',
+      seed: 12345,
+      playerInitial: player,
+      enemyInitial: enemy
+    });
+
+    expect(first).toEqual(second);
+  });
+
+  it('gives faster combatant more actions over 30 rounds', () => {
+    const result = simulateBattle({
+      battleId: 'speed-check',
+      seed: 999,
+      playerInitial: baseEntity({ entityId: 'fast', spd: 160 }),
+      enemyInitial: baseEntity({ entityId: 'slow', spd: 80, hp: 6000, def: 220 }),
+      maxRounds: 30
+    });
+
+    const actionEvents = result.events.filter((event) => event.type === 'ACTION');
+    const fastActions = actionEvents.filter((event) => event.actorId === 'fast').length;
+    const slowActions = actionEvents.filter((event) => event.actorId === 'slow').length;
+
+    expect(fastActions).toBeGreaterThan(slowActions);
+  });
+
+  it('uses timeout tiebreaker by hp then initiative then entityId', () => {
+    const result = simulateBattle({
+      battleId: 'timeout',
+      seed: 7,
+      playerInitial: baseEntity({
+        entityId: 'alpha',
+        hp: 10000,
+        atk: 10,
+        def: 10000,
+        spd: 101,
+        accuracyBP: 500,
+        evadeBP: 9500
+      }),
+      enemyInitial: baseEntity({
+        entityId: 'beta',
+        hp: 10000,
+        atk: 10,
+        def: 10000,
+        spd: 100,
+        accuracyBP: 500,
+        evadeBP: 9500
+      }),
+      maxRounds: 30
+    });
+
+    const battleEnd = result.events[result.events.length - 1];
+
+    expect(battleEnd).toEqual({
+      type: 'BATTLE_END',
+      round: 30,
+      winnerEntityId: 'alpha',
+      reason: 'timeout'
+    });
+    expect(result.winnerEntityId).toBe('alpha');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic 1v1 battle simulation (WO3 v0) with initiative scheduling, deterministic hit and damage resolution, and a complete event log for replay.

### Description
- Add `simulateBattle(input)` in `engine/battle/battleEngine.ts` implementing a max 30-round loop, per-round `initiative += SPD`, repeated actions while `initiative >= 100`, actor selection by `initiative desc`, `SPD desc`, `entityId asc`, and hardcoded `BASIC_ATTACK` action selection.
- Introduce initiative helpers in `engine/battle/initiative.ts` including `applyRoundInitiative`, `hasReadyActor`, `nextActorIndex`, and `timeoutWinner` with the specified tiebreakers.
- Add deterministic hit/damage resolution helpers in `engine/battle/resolveDamage.ts` with basis-point hit chance clamping, seeded roll `1..10000`, integer-only damage formula, and `resolveAttack` that returns hit info and damage.
- Emit a replayable event stream (`ROUND_START`, `ACTION`, `HIT_RESULT`, `DAMAGE`, `DEATH`, `ROUND_END`, `BATTLE_END`) and add `tests/battleEngine.v0.test.ts` that checks determinism, speed advantage (SPD 160 vs 80), and timeout tiebreaker behavior.
- Keep engine code pure TypeScript and free of Prisma/HTTP/UI imports and use the existing seeded `XorShift32` RNG.

### Testing
- Ran `npm ci` to install dependencies and then `npm test` to execute the test suite.
- All tests passed: 3 test suites, 8 tests (including the new `tests/battleEngine.v0.test.ts`) completed successfully under `jest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9349482988329aba6a7479a5a943e)