### PR TITLE
WO4: Add active skills, cooldowns, and deterministic AI action selection

### DIFF
--- a/engine/battle/aiDecision.ts
+++ b/engine/battle/aiDecision.ts
@@ -1,0 +1,66 @@
+import { BASIC_ATTACK_SKILL_ID, getSkillDef, type SkillDef } from './skillRegistry';
+
+export type DecisionCombatantSnapshot = {
+  hp: number;
+  hpMax: number;
+};
+
+export type CandidateAction = {
+  skillId: string;
+};
+
+const ACTIVE_AVAILABLE_BONUS = 200;
+const EXECUTE_BONUS = 500;
+
+function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
+  if (combatant.hpMax <= 0) {
+    return 0;
+  }
+
+  return Math.floor((combatant.hp * 10000) / combatant.hpMax);
+}
+
+function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot): number {
+  let score = skill.basePower;
+
+  if (skill.skillId !== BASIC_ATTACK_SKILL_ID) {
+    score += ACTIVE_AVAILABLE_BONUS;
+  }
+
+  if (skill.tags.includes('execute')) {
+    const targetHpBP = hpPercentBP(target);
+    const threshold = skill.executeThresholdBP ?? 0;
+
+    if (targetHpBP <= threshold) {
+      score += EXECUTE_BONUS;
+    }
+  }
+
+  return score;
+}
+
+export function chooseAction(
+  actorActiveSkillIds: readonly [string, string],
+  actorCooldowns: Record<string, number>,
+  target: DecisionCombatantSnapshot
+): CandidateAction {
+  const candidateSkillIds: string[] = [BASIC_ATTACK_SKILL_ID];
+
+  for (const activeSkillId of actorActiveSkillIds) {
+    if ((actorCooldowns[activeSkillId] ?? 0) === 0) {
+      candidateSkillIds.push(activeSkillId);
+    }
+  }
+
+  const ordered = candidateSkillIds
+    .map((skillId) => ({ skillId, score: scoreSkill(getSkillDef(skillId), target) }))
+    .sort((a, b) => {
+      if (a.score !== b.score) {
+        return b.score - a.score;
+      }
+
+      return a.skillId.localeCompare(b.skillId);
+    });
+
+  return { skillId: ordered[0].skillId };
+}

--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -1,30 +1,35 @@
 import { applyRoundInitiative, hasReadyActor, nextActorIndex, timeoutWinner } from './initiative';
 import { resolveAttack } from './resolveDamage';
 import { XorShift32 } from '../rng/xorshift32';
+import { chooseAction } from './aiDecision';
+import { BASIC_ATTACK_SKILL_ID, getSkillDef } from './skillRegistry';
 
-export type BattleEntity = {
+export type CombatantSnapshot = {
   entityId: string;
   hp: number;
+  hpMax: number;
   atk: number;
   def: number;
   spd: number;
   accuracyBP: number;
   evadeBP: number;
+  activeSkillIds: [string, string];
 };
 
 export type BattleInput = {
   battleId: string;
   seed: number;
-  playerInitial: BattleEntity;
-  enemyInitial: BattleEntity;
+  playerInitial: CombatantSnapshot;
+  enemyInitial: CombatantSnapshot;
   maxRounds?: number;
 };
 
 export type BattleEvent =
   | { type: 'ROUND_START'; round: number }
-  | { type: 'ACTION'; round: number; actorId: string; targetId: string; skillId: 'BASIC_ATTACK' }
+  | { type: 'ACTION'; round: number; actorId: string; targetId: string; skillId: string }
   | { type: 'HIT_RESULT'; round: number; actorId: string; targetId: string; hitChanceBP: number; rollBP: number; didHit: boolean }
   | { type: 'DAMAGE'; round: number; actorId: string; targetId: string; amount: number; targetHpAfter: number }
+  | { type: 'COOLDOWN_SET'; round: number; actorId: string; skillId: string; cooldownRemainingTurns: number }
   | { type: 'DEATH'; round: number; entityId: string }
   | { type: 'ROUND_END'; round: number }
   | { type: 'BATTLE_END'; round: number; winnerEntityId: string; reason: 'death' | 'timeout' };
@@ -32,23 +37,27 @@ export type BattleEvent =
 export type BattleResult = {
   battleId: string;
   seed: number;
-  playerInitial: BattleEntity;
-  enemyInitial: BattleEntity;
+  playerInitial: CombatantSnapshot;
+  enemyInitial: CombatantSnapshot;
   events: BattleEvent[];
   winnerEntityId: string;
   roundsPlayed: number;
 };
 
-type RuntimeEntity = BattleEntity & { initiative: number };
+type RuntimeEntity = CombatantSnapshot & { initiative: number; cooldowns: Record<string, number> };
 
-const BASIC_ATTACK = {
-  skillId: 'BASIC_ATTACK' as const,
-  basePower: 100,
-  accuracyModBP: 0
-};
+function cloneEntity(entity: CombatantSnapshot): CombatantSnapshot {
+  return { ...entity, activeSkillIds: [...entity.activeSkillIds] as [string, string] };
+}
 
-function cloneEntity(entity: BattleEntity): BattleEntity {
-  return { ...entity };
+function initializeCooldowns(entity: CombatantSnapshot): Record<string, number> {
+  return Object.fromEntries(entity.activeSkillIds.map((skillId) => [skillId, 0]));
+}
+
+function decrementCooldowns(entity: RuntimeEntity): void {
+  for (const skillId of entity.activeSkillIds) {
+    entity.cooldowns[skillId] = Math.max(0, (entity.cooldowns[skillId] ?? 0) - 1);
+  }
 }
 
 export function simulateBattle(input: BattleInput): BattleResult {
@@ -56,8 +65,16 @@ export function simulateBattle(input: BattleInput): BattleResult {
   const maxRounds = input.maxRounds ?? 30;
   const events: BattleEvent[] = [];
 
-  const player: RuntimeEntity = { ...cloneEntity(input.playerInitial), initiative: 0 };
-  const enemy: RuntimeEntity = { ...cloneEntity(input.enemyInitial), initiative: 0 };
+  const player: RuntimeEntity = {
+    ...cloneEntity(input.playerInitial),
+    initiative: 0,
+    cooldowns: initializeCooldowns(input.playerInitial)
+  };
+  const enemy: RuntimeEntity = {
+    ...cloneEntity(input.enemyInitial),
+    initiative: 0,
+    cooldowns: initializeCooldowns(input.enemyInitial)
+  };
   const combatants: RuntimeEntity[] = [player, enemy];
 
   let roundsPlayed = 0;
@@ -83,15 +100,33 @@ export function simulateBattle(input: BattleInput): BattleResult {
       }
 
       actor.initiative -= 100;
+
+      const selectedAction = chooseAction(actor.activeSkillIds, actor.cooldowns, {
+        hp: target.hp,
+        hpMax: target.hpMax
+      });
+      const selectedSkill = getSkillDef(selectedAction.skillId);
+
       events.push({
         type: 'ACTION',
         round,
         actorId: actor.entityId,
         targetId: target.entityId,
-        skillId: 'BASIC_ATTACK'
+        skillId: selectedSkill.skillId
       });
 
-      const attack = resolveAttack(actor, target, BASIC_ATTACK, rng);
+      if (selectedSkill.skillId !== BASIC_ATTACK_SKILL_ID) {
+        actor.cooldowns[selectedSkill.skillId] = selectedSkill.cooldownTurns;
+        events.push({
+          type: 'COOLDOWN_SET',
+          round,
+          actorId: actor.entityId,
+          skillId: selectedSkill.skillId,
+          cooldownRemainingTurns: selectedSkill.cooldownTurns
+        });
+      }
+
+      const attack = resolveAttack(actor, target, selectedSkill, rng);
       events.push({
         type: 'HIT_RESULT',
         round,
@@ -122,6 +157,8 @@ export function simulateBattle(input: BattleInput): BattleResult {
       }
     }
 
+    decrementCooldowns(player);
+    decrementCooldowns(enemy);
     events.push({ type: 'ROUND_END', round });
 
     if (winner !== null) {

--- a/engine/battle/skillRegistry.ts
+++ b/engine/battle/skillRegistry.ts
@@ -1,0 +1,52 @@
+export type SkillTag = 'execute';
+
+export type SkillDef = {
+  skillId: string;
+  basePower: number;
+  accuracyModBP: number;
+  cooldownTurns: number;
+  tags: SkillTag[];
+  executeThresholdBP?: number;
+};
+
+export const BASIC_ATTACK_SKILL_ID = 'BASIC_ATTACK';
+
+const BASIC_ATTACK: SkillDef = {
+  skillId: BASIC_ATTACK_SKILL_ID,
+  basePower: 100,
+  accuracyModBP: 0,
+  cooldownTurns: 0,
+  tags: []
+};
+
+const VOLT_STRIKE: SkillDef = {
+  skillId: 'VOLT_STRIKE',
+  basePower: 170,
+  accuracyModBP: 0,
+  cooldownTurns: 2,
+  tags: []
+};
+
+const FINISHING_BLOW: SkillDef = {
+  skillId: 'FINISHING_BLOW',
+  basePower: 140,
+  accuracyModBP: 300,
+  cooldownTurns: 3,
+  tags: ['execute'],
+  executeThresholdBP: 3000
+};
+
+const SKILL_REGISTRY: Record<string, SkillDef> = {
+  [BASIC_ATTACK.skillId]: BASIC_ATTACK,
+  [VOLT_STRIKE.skillId]: VOLT_STRIKE,
+  [FINISHING_BLOW.skillId]: FINISHING_BLOW
+};
+
+export function getSkillDef(skillId: string): SkillDef {
+  const skill = SKILL_REGISTRY[skillId];
+  if (skill === undefined) {
+    throw new Error(`Unknown skillId: ${skillId}`);
+  }
+
+  return skill;
+}

--- a/tests/battleEngine.skills.test.ts
+++ b/tests/battleEngine.skills.test.ts
@@ -1,0 +1,68 @@
+import { simulateBattle, type CombatantSnapshot } from '../engine/battle/battleEngine';
+
+function buildCombatant(overrides: Partial<CombatantSnapshot>): CombatantSnapshot {
+  return {
+    entityId: 'entity',
+    hp: 2000,
+    hpMax: 2000,
+    atk: 180,
+    def: 80,
+    spd: 100,
+    accuracyBP: 9000,
+    evadeBP: 1000,
+    activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW'],
+    ...overrides
+  };
+}
+
+describe('battleEngine skills', () => {
+  it('decrements cooldowns at round end and emits COOLDOWN_SET', () => {
+    const result = simulateBattle({
+      battleId: 'cooldown-round-end',
+      seed: 42,
+      playerInitial: buildCombatant({ entityId: 'player', atk: 60 }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', hp: 9000, hpMax: 9000, def: 2000, atk: 5 }),
+      maxRounds: 3
+    });
+
+    const playerRoundActions = result.events.filter(
+      (event): event is Extract<(typeof result.events)[number], { type: 'ACTION' }> =>
+        event.type === 'ACTION' && event.actorId === 'player'
+    );
+
+    const voltStrikeRounds = playerRoundActions
+      .filter((event) => event.skillId === 'VOLT_STRIKE')
+      .map((event) => event.round);
+
+    expect(voltStrikeRounds).toEqual([1, 3]);
+
+    const cooldownSet = result.events.filter(
+      (event): event is Extract<(typeof result.events)[number], { type: 'COOLDOWN_SET' }> =>
+        event.type === 'COOLDOWN_SET' && event.actorId === 'player' && event.skillId === 'VOLT_STRIKE'
+    );
+
+    expect(cooldownSet.length).toBeGreaterThanOrEqual(2);
+    expect(cooldownSet[0]).toEqual(
+      expect.objectContaining({ type: 'COOLDOWN_SET', round: 1, cooldownRemainingTurns: 2 })
+    );
+  });
+
+  it('AI uses execute when target HP percent is below threshold', () => {
+    const result = simulateBattle({
+      battleId: 'execute-threshold',
+      seed: 99,
+      playerInitial: buildCombatant({ entityId: 'player', spd: 120 }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', hp: 500, hpMax: 2000, def: 300, spd: 90 }),
+      maxRounds: 1
+    });
+
+    const firstAction = result.events.find(
+      (event): event is Extract<(typeof result.events)[number], { type: 'ACTION' }> =>
+        event.type === 'ACTION' && event.actorId === 'player'
+    );
+
+    expect(firstAction).toEqual(
+      expect.objectContaining({ type: 'ACTION', skillId: 'FINISHING_BLOW', round: 1 })
+    );
+  });
+});

--- a/tests/battleEngine.v0.test.ts
+++ b/tests/battleEngine.v0.test.ts
@@ -1,14 +1,16 @@
-import { simulateBattle, type BattleEntity } from '../engine/battle/battleEngine';
+import { simulateBattle, type CombatantSnapshot } from '../engine/battle/battleEngine';
 
-function baseEntity(overrides: Partial<BattleEntity>): BattleEntity {
+function baseEntity(overrides: Partial<CombatantSnapshot>): CombatantSnapshot {
   return {
     entityId: 'entity',
     hp: 2000,
+    hpMax: 2000,
     atk: 150,
     def: 120,
     spd: 100,
     accuracyBP: 8000,
     evadeBP: 1500,
+    activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW'],
     ...overrides
   };
 }
@@ -40,7 +42,7 @@ describe('battleEngine v0', () => {
       battleId: 'speed-check',
       seed: 999,
       playerInitial: baseEntity({ entityId: 'fast', spd: 160 }),
-      enemyInitial: baseEntity({ entityId: 'slow', spd: 80, hp: 6000, def: 220 }),
+      enemyInitial: baseEntity({ entityId: 'slow', spd: 80, hp: 6000, hpMax: 6000, def: 220 }),
       maxRounds: 30
     });
 
@@ -58,6 +60,7 @@ describe('battleEngine v0', () => {
       playerInitial: baseEntity({
         entityId: 'alpha',
         hp: 10000,
+        hpMax: 10000,
         atk: 10,
         def: 10000,
         spd: 101,
@@ -67,6 +70,7 @@ describe('battleEngine v0', () => {
       enemyInitial: baseEntity({
         entityId: 'beta',
         hp: 10000,
+        hpMax: 10000,
         atk: 10,
         def: 10000,
         spd: 100,


### PR DESCRIPTION
### Motivation
- Implement active skills + turn-based cooldowns and a simple deterministic AI to select between basic attack and two equipped actives per the SSOT cooldown and AI rules. 
- Emit cooldown lifecycle events in the battle event log so clients can replay and validate cooldown behavior.

### Description
- Added an in-memory skill registry `engine/battle/skillRegistry.ts` with `BASIC_ATTACK`, `VOLT_STRIKE`, and `FINISHING_BLOW` (including `cooldownTurns` and `executeThresholdBP`).
- Added deterministic AI scoring and selection in `engine/battle/aiDecision.ts` that evaluates `Basic Attack + 2 actives`, filters by cooldown availability, and applies an execute bonus using integer HP% (`hp * 10000 / hpMax`).
- Updated `engine/battle/battleEngine.ts` to accept a `CombatantSnapshot` with `activeSkillIds: [string,string]`, call the AI to choose actions, set cooldowns on active use, decrement cooldowns at `ROUND_END`, and emit `COOLDOWN_SET` events.
- Added and updated tests: `tests/battleEngine.skills.test.ts` (new) and updated `tests/battleEngine.v0.test.ts` to the new snapshot shape to cover cooldown decrement, `COOLDOWN_SET`, and execute-threshold selection.

### Testing
- Installed dependencies with `npm ci` and ran the test suite with `npm test -- --runInBand`.
- All automated tests passed: 4 test suites, 10 tests, all green (includes `tests/battleEngine.skills.test.ts`, `tests/battleEngine.v0.test.ts`, `tests/rng.test.ts`, `tests/smoke.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a936bf35e883299d6c0e02d7044052)