### PR TITLE
Add deterministic non-stacking status effects with end-of-round expiry

### DIFF
--- a/engine/battle/aiDecision.ts
+++ b/engine/battle/aiDecision.ts
@@ -1,8 +1,10 @@
 import { BASIC_ATTACK_SKILL_ID, getSkillDef, type SkillDef } from './skillRegistry';
+import type { StatusId } from './statusRegistry';
 
 export type DecisionCombatantSnapshot = {
   hp: number;
   hpMax: number;
+  statuses: readonly StatusId[];
 };
 
 export type CandidateAction = {
@@ -11,6 +13,8 @@ export type CandidateAction = {
 
 const ACTIVE_AVAILABLE_BONUS = 200;
 const EXECUTE_BONUS = 500;
+const SHIELDBREAK_BONUS = 350;
+const WASTED_STUN_PENALTY = 10_000;
 
 function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
   if (combatant.hpMax <= 0) {
@@ -34,6 +38,14 @@ function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot): number 
     if (targetHpBP <= threshold) {
       score += EXECUTE_BONUS;
     }
+  }
+
+  if (skill.tags.includes('stun') && target.statuses.includes('stunned')) {
+    score -= WASTED_STUN_PENALTY;
+  }
+
+  if (skill.tags.includes('shieldbreak') && target.statuses.includes('shielded')) {
+    score += SHIELDBREAK_BONUS;
   }
 
   return score;

--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -3,6 +3,8 @@ import { resolveAttack } from './resolveDamage';
 import { XorShift32 } from '../rng/xorshift32';
 import { chooseAction } from './aiDecision';
 import { BASIC_ATTACK_SKILL_ID, getSkillDef } from './skillRegistry';
+import { applyStatus, decrementStatusesAtRoundEnd, type ActiveStatuses } from './resolveStatus';
+import type { StatusId } from './statusRegistry';
 
 export type CombatantSnapshot = {
   entityId: string;
@@ -28,6 +30,15 @@ export type BattleEvent =
   | { type: 'ROUND_START'; round: number }
   | { type: 'ACTION'; round: number; actorId: string; targetId: string; skillId: string }
   | { type: 'HIT_RESULT'; round: number; actorId: string; targetId: string; hitChanceBP: number; rollBP: number; didHit: boolean }
+  | {
+      type: 'STATUS_APPLY' | 'STATUS_REFRESH';
+      round: number;
+      targetId: string;
+      statusId: StatusId;
+      sourceId: string;
+      remainingTurns: number;
+    }
+  | { type: 'STATUS_EXPIRE'; round: number; targetId: string; statusId: StatusId }
   | { type: 'DAMAGE'; round: number; actorId: string; targetId: string; amount: number; targetHpAfter: number }
   | { type: 'COOLDOWN_SET'; round: number; actorId: string; skillId: string; cooldownRemainingTurns: number }
   | { type: 'DEATH'; round: number; entityId: string }
@@ -44,7 +55,7 @@ export type BattleResult = {
   roundsPlayed: number;
 };
 
-type RuntimeEntity = CombatantSnapshot & { initiative: number; cooldowns: Record<string, number> };
+type RuntimeEntity = CombatantSnapshot & { initiative: number; cooldowns: Record<string, number>; statuses: ActiveStatuses };
 
 function cloneEntity(entity: CombatantSnapshot): CombatantSnapshot {
   return { ...entity, activeSkillIds: [...entity.activeSkillIds] as [string, string] };
@@ -60,6 +71,12 @@ function decrementCooldowns(entity: RuntimeEntity): void {
   }
 }
 
+function getActiveStatusIds(entity: RuntimeEntity): StatusId[] {
+  return Object.keys(entity.statuses)
+    .filter((statusId) => (entity.statuses[statusId as StatusId] ?? 0) > 0)
+    .sort() as StatusId[];
+}
+
 export function simulateBattle(input: BattleInput): BattleResult {
   const rng = new XorShift32(input.seed);
   const maxRounds = input.maxRounds ?? 30;
@@ -68,12 +85,14 @@ export function simulateBattle(input: BattleInput): BattleResult {
   const player: RuntimeEntity = {
     ...cloneEntity(input.playerInitial),
     initiative: 0,
-    cooldowns: initializeCooldowns(input.playerInitial)
+    cooldowns: initializeCooldowns(input.playerInitial),
+    statuses: {}
   };
   const enemy: RuntimeEntity = {
     ...cloneEntity(input.enemyInitial),
     initiative: 0,
-    cooldowns: initializeCooldowns(input.enemyInitial)
+    cooldowns: initializeCooldowns(input.enemyInitial),
+    statuses: {}
   };
   const combatants: RuntimeEntity[] = [player, enemy];
 
@@ -103,7 +122,8 @@ export function simulateBattle(input: BattleInput): BattleResult {
 
       const selectedAction = chooseAction(actor.activeSkillIds, actor.cooldowns, {
         hp: target.hp,
-        hpMax: target.hpMax
+        hpMax: target.hpMax,
+        statuses: getActiveStatusIds(target)
       });
       const selectedSkill = getSkillDef(selectedAction.skillId);
 
@@ -148,6 +168,10 @@ export function simulateBattle(input: BattleInput): BattleResult {
           targetHpAfter: target.hp
         });
 
+        for (const statusId of selectedSkill.appliesStatusIds ?? []) {
+          events.push(applyStatus(target.statuses, statusId, actor.entityId, target.entityId, round));
+        }
+
         if (target.hp === 0) {
           events.push({ type: 'DEATH', round, entityId: target.entityId });
           winner = actor;
@@ -159,6 +183,8 @@ export function simulateBattle(input: BattleInput): BattleResult {
 
     decrementCooldowns(player);
     decrementCooldowns(enemy);
+    events.push(...decrementStatusesAtRoundEnd(player.statuses, player.entityId, round));
+    events.push(...decrementStatusesAtRoundEnd(enemy.statuses, enemy.entityId, round));
     events.push({ type: 'ROUND_END', round });
 
     if (winner !== null) {

--- a/engine/battle/resolveStatus.ts
+++ b/engine/battle/resolveStatus.ts
@@ -1,0 +1,75 @@
+import { getStatusDef, type StatusId } from './statusRegistry';
+
+export type ActiveStatuses = Partial<Record<StatusId, number>>;
+
+export type StatusApplyEvent = {
+  type: 'STATUS_APPLY' | 'STATUS_REFRESH';
+  round: number;
+  targetId: string;
+  statusId: StatusId;
+  sourceId: string;
+  remainingTurns: number;
+};
+
+export type StatusExpireEvent = {
+  type: 'STATUS_EXPIRE';
+  round: number;
+  targetId: string;
+  statusId: StatusId;
+};
+
+export function applyStatus(
+  statuses: ActiveStatuses,
+  statusId: StatusId,
+  sourceId: string,
+  targetId: string,
+  round: number
+): StatusApplyEvent {
+  const statusDef = getStatusDef(statusId);
+  const nextRemainingTurns = statusDef.durationTurns;
+  const hadStatus = (statuses[statusId] ?? 0) > 0;
+
+  statuses[statusId] = nextRemainingTurns;
+
+  return {
+    type: hadStatus ? 'STATUS_REFRESH' : 'STATUS_APPLY',
+    round,
+    targetId,
+    statusId,
+    sourceId,
+    remainingTurns: nextRemainingTurns
+  };
+}
+
+export function decrementStatusesAtRoundEnd(
+  statuses: ActiveStatuses,
+  targetId: string,
+  round: number
+): StatusExpireEvent[] {
+  const expires: StatusExpireEvent[] = [];
+
+  const orderedStatusIds = Object.keys(statuses).sort() as StatusId[];
+  for (const statusId of orderedStatusIds) {
+    const remainingTurns = statuses[statusId] ?? 0;
+    if (remainingTurns <= 0) {
+      delete statuses[statusId];
+      continue;
+    }
+
+    const nextRemainingTurns = remainingTurns - 1;
+    if (nextRemainingTurns <= 0) {
+      delete statuses[statusId];
+      expires.push({
+        type: 'STATUS_EXPIRE',
+        round,
+        targetId,
+        statusId
+      });
+      continue;
+    }
+
+    statuses[statusId] = nextRemainingTurns;
+  }
+
+  return expires;
+}

--- a/engine/battle/skillRegistry.ts
+++ b/engine/battle/skillRegistry.ts
@@ -1,4 +1,6 @@
-export type SkillTag = 'execute';
+import type { StatusId } from './statusRegistry';
+
+export type SkillTag = 'execute' | 'stun' | 'shieldbreak';
 
 export type SkillDef = {
   skillId: string;
@@ -7,6 +9,7 @@ export type SkillDef = {
   cooldownTurns: number;
   tags: SkillTag[];
   executeThresholdBP?: number;
+  appliesStatusIds?: StatusId[];
 };
 
 export const BASIC_ATTACK_SKILL_ID = 'BASIC_ATTACK';
@@ -16,7 +19,8 @@ const BASIC_ATTACK: SkillDef = {
   basePower: 100,
   accuracyModBP: 0,
   cooldownTurns: 0,
-  tags: []
+  tags: [],
+  appliesStatusIds: []
 };
 
 const VOLT_STRIKE: SkillDef = {
@@ -24,7 +28,8 @@ const VOLT_STRIKE: SkillDef = {
   basePower: 170,
   accuracyModBP: 0,
   cooldownTurns: 2,
-  tags: []
+  tags: ['shieldbreak'],
+  appliesStatusIds: ['broken_armor']
 };
 
 const FINISHING_BLOW: SkillDef = {
@@ -32,8 +37,9 @@ const FINISHING_BLOW: SkillDef = {
   basePower: 140,
   accuracyModBP: 300,
   cooldownTurns: 3,
-  tags: ['execute'],
-  executeThresholdBP: 3000
+  tags: ['execute', 'stun'],
+  executeThresholdBP: 3000,
+  appliesStatusIds: ['stunned']
 };
 
 const SKILL_REGISTRY: Record<string, SkillDef> = {

--- a/engine/battle/statusRegistry.ts
+++ b/engine/battle/statusRegistry.ts
@@ -1,0 +1,18 @@
+export type StatusId = 'stunned' | 'shielded' | 'broken_armor' | 'silenced' | 'resist';
+
+export type StatusDef = {
+  id: StatusId;
+  durationTurns: number;
+};
+
+const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
+  stunned: { id: 'stunned', durationTurns: 1 },
+  shielded: { id: 'shielded', durationTurns: 2 },
+  broken_armor: { id: 'broken_armor', durationTurns: 2 },
+  silenced: { id: 'silenced', durationTurns: 1 },
+  resist: { id: 'resist', durationTurns: 3 }
+};
+
+export function getStatusDef(statusId: StatusId): StatusDef {
+  return STATUS_REGISTRY[statusId];
+}

--- a/tests/statuses.test.ts
+++ b/tests/statuses.test.ts
@@ -1,0 +1,40 @@
+import { applyStatus, decrementStatusesAtRoundEnd, type ActiveStatuses } from '../engine/battle/resolveStatus';
+
+describe('status resolution', () => {
+  it('refreshes duration when reapplied instead of stacking', () => {
+    const statuses: ActiveStatuses = {};
+
+    const applyEvent = applyStatus(statuses, 'stunned', 'actor-a', 'target-a', 1);
+    const refreshEvent = applyStatus(statuses, 'stunned', 'actor-a', 'target-a', 2);
+
+    expect(applyEvent.type).toBe('STATUS_APPLY');
+    expect(refreshEvent.type).toBe('STATUS_REFRESH');
+    expect(statuses.stunned).toBe(1);
+  });
+
+  it('expires statuses at end of round when remaining turns reaches zero', () => {
+    const statuses: ActiveStatuses = {};
+    applyStatus(statuses, 'stunned', 'actor-a', 'target-a', 1);
+
+    const expires = decrementStatusesAtRoundEnd(statuses, 'target-a', 1);
+
+    expect(expires).toEqual([
+      {
+        type: 'STATUS_EXPIRE',
+        round: 1,
+        targetId: 'target-a',
+        statusId: 'stunned'
+      }
+    ]);
+    expect(statuses.stunned).toBeUndefined();
+  });
+
+  it('does not increase active status count when reapplied', () => {
+    const statuses: ActiveStatuses = {};
+    applyStatus(statuses, 'resist', 'actor-a', 'target-a', 1);
+    applyStatus(statuses, 'resist', 'actor-b', 'target-a', 1);
+
+    expect(Object.keys(statuses)).toHaveLength(1);
+    expect(statuses.resist).toBe(3);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a deterministic, non-stacking status system with bounded durations (1–3 turns) to support effects like stun/shield/resist per the SSOT combat rules. 
- Ensure status lifecycle is deterministic and emits events for apply/refresh/expire so battle logs remain fully reconstructable.

### Description
- Introduced a status registry `engine/battle/statusRegistry.ts` defining `stunned`, `shielded`, `broken_armor`, `silenced`, and `resist` with fixed `durationTurns` in the 1–3 range. 
- Implemented status resolution helpers in `engine/battle/resolveStatus.ts` that apply or refresh (no stacking) and decrement/emit `STATUS_EXPIRE` at end of round. 
- Integrated status handling into the battle loop (`engine/battle/battleEngine.ts`) so skills can apply statuses and round-end processing decrements and emits expiry events. 
- Extended `engine/battle/skillRegistry.ts` with status application metadata and added tags for `stun` and `shieldbreak`, and updated AI (`engine/battle/aiDecision.ts`) to avoid wasting stun and prefer shieldbreak against shielded targets. 
- Added unit tests `tests/statuses.test.ts` to assert refresh behavior, expiry behavior, and non-stacking guarantees.

### Testing
- Ran dependency install with `npm ci` successfully. 
- Ran the full test suite with `npm test -- --runInBand` and all tests passed (5 test suites, 13 tests). 
- New tests include `tests/statuses.test.ts` which passed and verifies apply/refresh/expire and non-stacking behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a938c9965c8329bce1b75fb4048205)