### PR TITLE
Implement MVP passive system (registry, application, tests)

### DIFF
--- a/engine/battle/applyPassives.ts
+++ b/engine/battle/applyPassives.ts
@@ -1,0 +1,112 @@
+import type { AttackSkill, AttackSnapshot } from './resolveDamage';
+import { getPassiveDef, type ConditionalPassiveModifier, type PassiveStatKey, type PassiveStatModifiers } from './passiveRegistry';
+
+type BattleStatBlock = {
+  hp: number;
+  hpMax: number;
+  atk: number;
+  def: number;
+  spd: number;
+  accuracyBP: number;
+  evadeBP: number;
+};
+
+type SnapshotWithPassives = AttackSnapshot &
+  BattleStatBlock & {
+    passiveSkillIds?: readonly string[];
+  };
+
+type AttackContext = {
+  actor: SnapshotWithPassives;
+  target: SnapshotWithPassives;
+  skill: AttackSkill;
+};
+
+const STAT_KEYS: PassiveStatKey[] = ['hp', 'hpMax', 'atk', 'def', 'spd', 'accuracyBP', 'evadeBP'];
+
+function applyStats(base: BattleStatBlock, modifiers?: PassiveStatModifiers): BattleStatBlock {
+  if (modifiers === undefined) {
+    return base;
+  }
+
+  const next = { ...base };
+  for (const statKey of STAT_KEYS) {
+    const delta = modifiers[statKey] ?? 0;
+    if (delta !== 0) {
+      next[statKey] += delta;
+    }
+  }
+
+  return next;
+}
+
+function hpPercentBP(entity: Pick<SnapshotWithPassives, 'hp' | 'hpMax'>): number {
+  if (entity.hpMax <= 0) {
+    return 0;
+  }
+
+  return Math.floor((entity.hp * 10000) / entity.hpMax);
+}
+
+function conditionMatches(condition: ConditionalPassiveModifier['when'], context: AttackContext): boolean {
+  if (condition.kind === 'target_hp_below_bp') {
+    return hpPercentBP(context.target) <= condition.thresholdBP;
+  }
+
+  return false;
+}
+
+function collectFlatModifiers(passiveSkillIds: readonly string[]): PassiveStatModifiers {
+  return passiveSkillIds.reduce<PassiveStatModifiers>((acc, passiveId) => {
+    const passive = getPassiveDef(passiveId);
+    for (const statKey of STAT_KEYS) {
+      const delta = passive.flatStats?.[statKey] ?? 0;
+      if (delta !== 0) {
+        acc[statKey] = (acc[statKey] ?? 0) + delta;
+      }
+    }
+
+    return acc;
+  }, {});
+}
+
+export function applyFlatPassives<T extends SnapshotWithPassives>(snapshot: T): T {
+  const flatStats = collectFlatModifiers(snapshot.passiveSkillIds ?? []);
+  const nextStats = applyStats(snapshot, flatStats);
+  return { ...snapshot, ...nextStats };
+}
+
+function applyModifierToEntity(entity: SnapshotWithPassives, modifiers?: PassiveStatModifiers): SnapshotWithPassives {
+  const nextStats = applyStats(entity, modifiers);
+  return { ...entity, ...nextStats };
+}
+
+export function applyConditionalPassives(context: AttackContext): {
+  actor: AttackSnapshot;
+  target: AttackSnapshot;
+  skill: AttackSkill;
+} {
+  let actor = { ...context.actor };
+  let target = { ...context.target };
+  let skill = { ...context.skill };
+
+  for (const passiveId of context.actor.passiveSkillIds ?? []) {
+    const passive = getPassiveDef(passiveId);
+
+    for (const modifier of passive.conditional ?? []) {
+      if (!conditionMatches(modifier.when, { actor, target, skill })) {
+        continue;
+      }
+
+      actor = applyModifierToEntity(actor, modifier.actorStats);
+      target = applyModifierToEntity(target, modifier.targetStats);
+      skill = { ...skill, accuracyModBP: skill.accuracyModBP + (modifier.skillAccuracyModBP ?? 0) };
+    }
+  }
+
+  return {
+    actor,
+    target,
+    skill
+  };
+}

--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -5,6 +5,7 @@ import { chooseAction } from './aiDecision';
 import { BASIC_ATTACK_SKILL_ID, getSkillDef } from './skillRegistry';
 import { applyStatus, decrementStatusesAtRoundEnd, type ActiveStatuses } from './resolveStatus';
 import type { StatusId } from './statusRegistry';
+import { applyConditionalPassives, applyFlatPassives } from './applyPassives';
 
 export type CombatantSnapshot = {
   entityId: string;
@@ -16,6 +17,7 @@ export type CombatantSnapshot = {
   accuracyBP: number;
   evadeBP: number;
   activeSkillIds: [string, string];
+  passiveSkillIds?: [string, string];
 };
 
 export type BattleInput = {
@@ -58,7 +60,16 @@ export type BattleResult = {
 type RuntimeEntity = CombatantSnapshot & { initiative: number; cooldowns: Record<string, number>; statuses: ActiveStatuses };
 
 function cloneEntity(entity: CombatantSnapshot): CombatantSnapshot {
-  return { ...entity, activeSkillIds: [...entity.activeSkillIds] as [string, string] };
+  const cloned: CombatantSnapshot = {
+    ...entity,
+    activeSkillIds: [...entity.activeSkillIds] as [string, string]
+  };
+
+  if (entity.passiveSkillIds !== undefined) {
+    cloned.passiveSkillIds = [...entity.passiveSkillIds] as [string, string];
+  }
+
+  return cloned;
 }
 
 function initializeCooldowns(entity: CombatantSnapshot): Record<string, number> {
@@ -83,13 +94,13 @@ export function simulateBattle(input: BattleInput): BattleResult {
   const events: BattleEvent[] = [];
 
   const player: RuntimeEntity = {
-    ...cloneEntity(input.playerInitial),
+    ...applyFlatPassives(cloneEntity(input.playerInitial)),
     initiative: 0,
     cooldowns: initializeCooldowns(input.playerInitial),
     statuses: {}
   };
   const enemy: RuntimeEntity = {
-    ...cloneEntity(input.enemyInitial),
+    ...applyFlatPassives(cloneEntity(input.enemyInitial)),
     initiative: 0,
     cooldowns: initializeCooldowns(input.enemyInitial),
     statuses: {}
@@ -146,7 +157,13 @@ export function simulateBattle(input: BattleInput): BattleResult {
         });
       }
 
-      const attack = resolveAttack(actor, target, selectedSkill, rng);
+      const attackContext = applyConditionalPassives({
+        actor,
+        target,
+        skill: selectedSkill
+      });
+
+      const attack = resolveAttack(attackContext.actor, attackContext.target, attackContext.skill, rng);
       events.push({
         type: 'HIT_RESULT',
         round,

--- a/engine/battle/passiveRegistry.ts
+++ b/engine/battle/passiveRegistry.ts
@@ -1,0 +1,52 @@
+export type PassiveStatKey = 'hp' | 'hpMax' | 'atk' | 'def' | 'spd' | 'accuracyBP' | 'evadeBP';
+
+export type PassiveStatModifiers = Partial<Record<PassiveStatKey, number>>;
+
+export type PassiveCondition =
+  | {
+      kind: 'target_hp_below_bp';
+      thresholdBP: number;
+    };
+
+export type ConditionalPassiveModifier = {
+  when: PassiveCondition;
+  actorStats?: PassiveStatModifiers;
+  targetStats?: PassiveStatModifiers;
+  skillAccuracyModBP?: number;
+};
+
+export type PassiveDef = {
+  passiveId: string;
+  flatStats?: PassiveStatModifiers;
+  conditional?: ConditionalPassiveModifier[];
+};
+
+const PASSIVE_REGISTRY: Record<string, PassiveDef> = {
+  EAGLE_EYE: {
+    passiveId: 'EAGLE_EYE',
+    flatStats: {
+      accuracyBP: 1000
+    }
+  },
+  EXECUTIONER_FOCUS: {
+    passiveId: 'EXECUTIONER_FOCUS',
+    conditional: [
+      {
+        when: {
+          kind: 'target_hp_below_bp',
+          thresholdBP: 3000
+        },
+        skillAccuracyModBP: 1200
+      }
+    ]
+  }
+};
+
+export function getPassiveDef(passiveId: string): PassiveDef {
+  const passive = PASSIVE_REGISTRY[passiveId];
+  if (passive === undefined) {
+    throw new Error(`Unknown passiveId: ${passiveId}`);
+  }
+
+  return passive;
+}

--- a/tests/passives.test.ts
+++ b/tests/passives.test.ts
@@ -1,0 +1,52 @@
+import { simulateBattle, type CombatantSnapshot } from '../engine/battle/battleEngine';
+
+function buildCombatant(overrides: Partial<CombatantSnapshot>): CombatantSnapshot {
+  return {
+    entityId: 'entity',
+    hp: 2000,
+    hpMax: 2000,
+    atk: 160,
+    def: 120,
+    spd: 100,
+    accuracyBP: 6500,
+    evadeBP: 6000,
+    activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW'],
+    passiveSkillIds: ['EAGLE_EYE', 'EXECUTIONER_FOCUS'],
+    ...overrides
+  };
+}
+
+function firstHitResultForActor(result: ReturnType<typeof simulateBattle>, actorId: string) {
+  return result.events.find(
+    (event): event is Extract<(typeof result.events)[number], { type: 'HIT_RESULT' }> =>
+      event.type === 'HIT_RESULT' && event.actorId === actorId
+  );
+}
+
+describe('passives', () => {
+  it('flat passives modify accuracyBP and deterministically change hit outcomes', () => {
+    const withoutPassive = simulateBattle({
+      battleId: 'without-passive',
+      seed: 27,
+      playerInitial: buildCombatant({ entityId: 'player', passiveSkillIds: undefined }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', passiveSkillIds: undefined }),
+      maxRounds: 1
+    });
+
+    const withPassive = simulateBattle({
+      battleId: 'with-passive',
+      seed: 27,
+      playerInitial: buildCombatant({ entityId: 'player', passiveSkillIds: ['EAGLE_EYE', 'EXECUTIONER_FOCUS'] }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', passiveSkillIds: undefined }),
+      maxRounds: 1
+    });
+
+    expect(firstHitResultForActor(withoutPassive, 'player')).toEqual(
+      expect.objectContaining({ hitChanceBP: 500, rollBP: 553, didHit: false })
+    );
+
+    expect(firstHitResultForActor(withPassive, 'player')).toEqual(
+      expect.objectContaining({ hitChanceBP: 1500, rollBP: 553, didHit: true })
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a minimal, deterministic passive system so passives can alter combat snapshots at battle start and per-action without adding complex triggers, satisfying WO6 requirements.
- Ensure passives are pure engine-side transformations that can deterministically change hit outcomes and integrate with existing RNG-driven resolution rules. 

### Description
- Added `engine/battle/passiveRegistry.ts` which defines `PassiveDef`, flat stat modifiers, and a minimal conditional shape (`target_hp_below_bp`) with a `getPassiveDef` lookup. 
- Added `engine/battle/applyPassives.ts` with `applyFlatPassives` to apply always-on stat deltas at initialization and `applyConditionalPassives` to evaluate simple conditional modifiers per action and return an adjusted attack context. 
- Updated `engine/battle/battleEngine.ts` to accept optional `passiveSkillIds` on snapshots, clone/pass through passive slots, apply flat passives when creating runtime entities, and invoke `applyConditionalPassives` just before `resolveAttack`. 
- Added `tests/passives.test.ts` which asserts that a flat passive (`EAGLE_EYE`) raises `accuracyBP` and deterministically flips a hit outcome under the same seed/roll. 

### Testing
- Ran `npm ci` to install dependencies and then `npm test -- --runInBand` to execute the suite. 
- All automated tests passed: `6` test suites and `14` tests succeeded, including the new `passives` test that verifies deterministic hit changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93c1d33508329ae694effc2654cb5)