### PR TITLE
Implement WO7 per-skill learning weights and deterministic post-battle updates

### DIFF
--- a/engine/battle/aiDecision.ts
+++ b/engine/battle/aiDecision.ts
@@ -1,5 +1,6 @@
 import { BASIC_ATTACK_SKILL_ID, getSkillDef, type SkillDef } from './skillRegistry';
 import type { StatusId } from './statusRegistry';
+import { scoreLearnedWeightTerm, type ArchetypeSkillWeights } from './learning';
 
 export type DecisionCombatantSnapshot = {
   hp: number;
@@ -24,7 +25,7 @@ function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
   return Math.floor((combatant.hp * 10000) / combatant.hpMax);
 }
 
-function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot): number {
+function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot, skillWeights: ArchetypeSkillWeights): number {
   let score = skill.basePower;
 
   if (skill.skillId !== BASIC_ATTACK_SKILL_ID) {
@@ -48,13 +49,16 @@ function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot): number 
     score += SHIELDBREAK_BONUS;
   }
 
+  score += scoreLearnedWeightTerm(skillWeights, skill.skillId);
+
   return score;
 }
 
 export function chooseAction(
   actorActiveSkillIds: readonly [string, string],
   actorCooldowns: Record<string, number>,
-  target: DecisionCombatantSnapshot
+  target: DecisionCombatantSnapshot,
+  skillWeights: ArchetypeSkillWeights = {}
 ): CandidateAction {
   const candidateSkillIds: string[] = [BASIC_ATTACK_SKILL_ID];
 
@@ -65,7 +69,7 @@ export function chooseAction(
   }
 
   const ordered = candidateSkillIds
-    .map((skillId) => ({ skillId, score: scoreSkill(getSkillDef(skillId), target) }))
+    .map((skillId) => ({ skillId, score: scoreSkill(getSkillDef(skillId), target, skillWeights) }))
     .sort((a, b) => {
       if (a.score !== b.score) {
         return b.score - a.score;

--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -6,6 +6,7 @@ import { BASIC_ATTACK_SKILL_ID, getSkillDef } from './skillRegistry';
 import { applyStatus, decrementStatusesAtRoundEnd, type ActiveStatuses } from './resolveStatus';
 import type { StatusId } from './statusRegistry';
 import { applyConditionalPassives, applyFlatPassives } from './applyPassives';
+import type { ArchetypeSkillWeights } from './learning';
 
 export type CombatantSnapshot = {
   entityId: string;
@@ -25,6 +26,8 @@ export type BattleInput = {
   seed: number;
   playerInitial: CombatantSnapshot;
   enemyInitial: CombatantSnapshot;
+  playerSkillWeights?: ArchetypeSkillWeights;
+  enemySkillWeights?: ArchetypeSkillWeights;
   maxRounds?: number;
 };
 
@@ -135,7 +138,7 @@ export function simulateBattle(input: BattleInput): BattleResult {
         hp: target.hp,
         hpMax: target.hpMax,
         statuses: getActiveStatusIds(target)
-      });
+      }, actorIndex === 0 ? (input.playerSkillWeights ?? {}) : (input.enemySkillWeights ?? {}));
       const selectedSkill = getSkillDef(selectedAction.skillId);
 
       events.push({

--- a/engine/battle/learning.ts
+++ b/engine/battle/learning.ts
@@ -1,0 +1,82 @@
+import type { BattleEvent } from './battleEngine';
+
+export const MIN_LEARNING_WEIGHT = -1000;
+export const MAX_LEARNING_WEIGHT = 1000;
+export const DEFAULT_LEARNING_RATE = 150;
+
+export type ArchetypeSkillWeights = Record<string, number>;
+
+export type SkillContribution = {
+  damageDealt: number;
+  statusTurnsApplied: number;
+};
+
+export type SkillContributions = Record<string, SkillContribution>;
+
+function clampWeight(weight: number): number {
+  return Math.min(MAX_LEARNING_WEIGHT, Math.max(MIN_LEARNING_WEIGHT, weight));
+}
+
+export function getLearnedWeight(skillWeights: ArchetypeSkillWeights, skillId: string): number {
+  return clampWeight(skillWeights[skillId] ?? 0);
+}
+
+export function scoreLearnedWeightTerm(skillWeights: ArchetypeSkillWeights, skillId: string): number {
+  return getLearnedWeight(skillWeights, skillId);
+}
+
+export function buildSkillContributions(events: readonly BattleEvent[], actorId: string): SkillContributions {
+  const contributions: SkillContributions = {};
+  const latestActionSkillByActor: Record<string, string> = {};
+
+  for (const event of events) {
+    if (event.type === 'ACTION') {
+      latestActionSkillByActor[event.actorId] = event.skillId;
+      continue;
+    }
+
+    if (event.type === 'DAMAGE' && event.actorId === actorId) {
+      const skillId = latestActionSkillByActor[event.actorId];
+      if (skillId !== undefined) {
+        const entry = (contributions[skillId] ??= { damageDealt: 0, statusTurnsApplied: 0 });
+        entry.damageDealt += event.amount;
+      }
+      continue;
+    }
+
+    if ((event.type === 'STATUS_APPLY' || event.type === 'STATUS_REFRESH') && event.sourceId === actorId) {
+      const skillId = latestActionSkillByActor[event.sourceId];
+      if (skillId !== undefined) {
+        const entry = (contributions[skillId] ??= { damageDealt: 0, statusTurnsApplied: 0 });
+        entry.statusTurnsApplied += event.remainingTurns;
+      }
+    }
+  }
+
+  return contributions;
+}
+
+export function updateSkillWeights(params: {
+  currentSkillWeights: ArchetypeSkillWeights;
+  skillContributions: SkillContributions;
+  enemyHpMax: number;
+  didWin: boolean;
+  learningRate?: number;
+}): ArchetypeSkillWeights {
+  const learningRate = params.learningRate ?? DEFAULT_LEARNING_RATE;
+  const sign = params.didWin ? 1 : -1;
+  const nextSkillWeights: ArchetypeSkillWeights = { ...params.currentSkillWeights };
+  const safeEnemyHpMax = Math.max(1, params.enemyHpMax);
+
+  for (const [skillId, contribution] of Object.entries(params.skillContributions)) {
+    const damagePart = Math.floor((contribution.damageDealt * 1000) / safeEnemyHpMax);
+    const statusPart = Math.floor((contribution.statusTurnsApplied * 1000) / 3);
+    const contrib = Math.floor((700 * damagePart + 300 * statusPart) / 1000);
+
+    const delta = sign * Math.floor((learningRate * contrib) / 1000);
+    const currentWeight = nextSkillWeights[skillId] ?? 0;
+    nextSkillWeights[skillId] = clampWeight(currentWeight + delta);
+  }
+
+  return nextSkillWeights;
+}

--- a/tests/learning.test.ts
+++ b/tests/learning.test.ts
@@ -1,0 +1,152 @@
+import { chooseAction } from '../engine/battle/aiDecision';
+import { simulateBattle, type CombatantSnapshot } from '../engine/battle/battleEngine';
+import {
+  MAX_LEARNING_WEIGHT,
+  MIN_LEARNING_WEIGHT,
+  buildSkillContributions,
+  updateSkillWeights,
+  type ArchetypeSkillWeights
+} from '../engine/battle/learning';
+
+function buildCombatant(overrides: Partial<CombatantSnapshot>): CombatantSnapshot {
+  return {
+    entityId: 'entity',
+    hp: 2200,
+    hpMax: 2200,
+    atk: 190,
+    def: 90,
+    spd: 110,
+    accuracyBP: 9000,
+    evadeBP: 800,
+    activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW'],
+    ...overrides
+  };
+}
+
+function firstPlayerActionSkillId(weights: ArchetypeSkillWeights): string {
+  const result = simulateBattle({
+    battleId: 'learning-first-action',
+    seed: 77,
+    playerInitial: buildCombatant({ entityId: 'player', spd: 120, accuracyBP: 10000 }),
+    enemyInitial: buildCombatant({ entityId: 'enemy', hp: 6000, hpMax: 6000, def: 140, spd: 70, atk: 80, evadeBP: 0 }),
+    playerSkillWeights: weights,
+    maxRounds: 1
+  });
+
+  const firstAction = result.events.find(
+    (event): event is Extract<(typeof result.events)[number], { type: 'ACTION' }> =>
+      event.type === 'ACTION' && event.actorId === 'player'
+  );
+
+  if (firstAction === undefined) {
+    throw new Error('Expected player ACTION event.');
+  }
+
+  return firstAction.skillId;
+}
+
+describe('learning', () => {
+  it('increasingly favors more effective skills across runs with persisted weights', () => {
+    let weights: ArchetypeSkillWeights = {};
+    const observedVoltWeights: number[] = [];
+
+    for (let run = 1; run <= 4; run += 1) {
+      const result = simulateBattle({
+        battleId: `learning-run-${run}`,
+        seed: 77,
+        playerInitial: buildCombatant({ entityId: 'player', spd: 120 }),
+        enemyInitial: buildCombatant({ entityId: 'enemy', hp: 6000, hpMax: 6000, def: 140, spd: 70, atk: 80 }),
+        playerSkillWeights: weights,
+        maxRounds: 3
+      });
+
+      const skillContributions = buildSkillContributions(result.events, 'player');
+      weights = updateSkillWeights({
+        currentSkillWeights: weights,
+        skillContributions,
+        enemyHpMax: result.enemyInitial.hpMax,
+        didWin: true
+      });
+
+      observedVoltWeights.push(weights.VOLT_STRIKE ?? 0);
+    }
+
+    expect(observedVoltWeights[0]).toBeGreaterThan(0);
+    for (let index = 1; index < observedVoltWeights.length; index += 1) {
+      expect(observedVoltWeights[index]).toBeGreaterThan(observedVoltWeights[index - 1]);
+    }
+    expect(firstPlayerActionSkillId(weights)).toBe('VOLT_STRIKE');
+  });
+
+  it('clamps weights to [-1000, 1000]', () => {
+    const saturatedPositive = updateSkillWeights({
+      currentSkillWeights: { VOLT_STRIKE: 999 },
+      skillContributions: { VOLT_STRIKE: { damageDealt: 999999, statusTurnsApplied: 10 } },
+      enemyHpMax: 1,
+      didWin: true
+    });
+
+    const saturatedNegative = updateSkillWeights({
+      currentSkillWeights: { FINISHING_BLOW: -999 },
+      skillContributions: { FINISHING_BLOW: { damageDealt: 999999, statusTurnsApplied: 10 } },
+      enemyHpMax: 1,
+      didWin: false
+    });
+
+    expect(saturatedPositive.VOLT_STRIKE).toBe(MAX_LEARNING_WEIGHT);
+    expect(saturatedNegative.FINISHING_BLOW).toBe(MIN_LEARNING_WEIGHT);
+  });
+
+  it('remains deterministic for same seed and initial weights', () => {
+    const initialWeights: ArchetypeSkillWeights = { VOLT_STRIKE: 25, FINISHING_BLOW: -10 };
+
+    const runA = simulateBattle({
+      battleId: 'determinism-a',
+      seed: 314,
+      playerInitial: buildCombatant({ entityId: 'player' }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', hp: 5000, hpMax: 5000, spd: 80 }),
+      playerSkillWeights: initialWeights,
+      maxRounds: 3
+    });
+
+    const runB = simulateBattle({
+      battleId: 'determinism-b',
+      seed: 314,
+      playerInitial: buildCombatant({ entityId: 'player' }),
+      enemyInitial: buildCombatant({ entityId: 'enemy', hp: 5000, hpMax: 5000, spd: 80 }),
+      playerSkillWeights: initialWeights,
+      maxRounds: 3
+    });
+
+    expect(runA.events).toEqual(runB.events);
+
+    const contributionsA = buildSkillContributions(runA.events, 'player');
+    const contributionsB = buildSkillContributions(runB.events, 'player');
+
+    expect(contributionsA).toEqual(contributionsB);
+    expect(
+      updateSkillWeights({
+        currentSkillWeights: initialWeights,
+        skillContributions: contributionsA,
+        enemyHpMax: runA.enemyInitial.hpMax,
+        didWin: runA.winnerEntityId === 'player'
+      })
+    ).toEqual(
+      updateSkillWeights({
+        currentSkillWeights: initialWeights,
+        skillContributions: contributionsB,
+        enemyHpMax: runB.enemyInitial.hpMax,
+        didWin: runB.winnerEntityId === 'player'
+      })
+    );
+
+    const weightedChoice = chooseAction(
+      ['VOLT_STRIKE', 'FINISHING_BLOW'],
+      { VOLT_STRIKE: 0, FINISHING_BLOW: 0 },
+      { hp: 4000, hpMax: 6000, statuses: [] },
+      { VOLT_STRIKE: 100, FINISHING_BLOW: -100 }
+    );
+
+    expect(weightedChoice.skillId).toBe('VOLT_STRIKE');
+  });
+});


### PR DESCRIPTION
### Motivation
- Add deterministic per-character, per-archetype learning so AI choices evolve from combat outcomes as defined in `docs/SSOT.md` (weights in [-1000..1000]).
- Make AI scoring include a learned weight term so persisted weights can bias action selection across runs.
- Provide an integer-only, per-mille post-battle update rule with `learningRate = 150` to adjust weights from observed per-skill contributions.

### Description
- Add `engine/battle/learning.ts` implementing weight bounds, `getLearnedWeight`, `scoreLearnedWeightTerm`, `buildSkillContributions` (damage + status turns), and `updateSkillWeights` (integer per-mille formula, clamp to `[-1000,1000]`).
- Extend AI scoring: `chooseAction` now accepts optional `skillWeights: ArchetypeSkillWeights` and includes `scoreLearnedWeightTerm` in the candidate score calculation.
- Extend battle input and simulation: `BattleInput` accepts `playerSkillWeights` and `enemySkillWeights` and `simulateBattle` passes the appropriate weights into `chooseAction` for deterministic decision-making.
- Add `tests/learning.test.ts` which verifies increasing preference from persisted weights over repeated runs, weight clamping at `MIN/MAX_LEARNING_WEIGHT`, and determinism for identical seed + initial weights.

### Testing
- Ran the unit tests targeting learning and full suite locally with `npm test -- tests/learning.test.ts --runInBand` and `npm test -- --runInBand`.
- The learning test file (`tests/learning.test.ts`) passed in isolation and collectively with the rest of the suite.
- Final test run: all test suites passed (`7` suites, `17` tests) indicating the new code and integrations are green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93f65b280832996699257644443a6)