### PR TITLE
WO8: add minimal Next.js combat vertical slice (API + UI replay)

### DIFF
--- a/app/api/combat/route.ts
+++ b/app/api/combat/route.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+
+import { simulateBattle, type CombatantSnapshot } from '../../../engine/battle/battleEngine';
+
+type CombatRequestBody = {
+  playerInitial: CombatantSnapshot;
+  enemyInitial: CombatantSnapshot;
+  seed: number;
+};
+
+function isCombatantSnapshot(value: unknown): value is CombatantSnapshot {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const snapshot = value as Partial<CombatantSnapshot>;
+
+  return (
+    typeof snapshot.entityId === 'string' &&
+    typeof snapshot.hp === 'number' &&
+    typeof snapshot.hpMax === 'number' &&
+    typeof snapshot.atk === 'number' &&
+    typeof snapshot.def === 'number' &&
+    typeof snapshot.spd === 'number' &&
+    typeof snapshot.accuracyBP === 'number' &&
+    typeof snapshot.evadeBP === 'number' &&
+    Array.isArray(snapshot.activeSkillIds) &&
+    snapshot.activeSkillIds.length === 2 &&
+    snapshot.activeSkillIds.every((skillId) => typeof skillId === 'string')
+  );
+}
+
+export async function POST(request: Request) {
+  let body: Partial<CombatRequestBody>;
+
+  try {
+    body = (await request.json()) as Partial<CombatRequestBody>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (
+    typeof body.seed !== 'number' ||
+    !isCombatantSnapshot(body.playerInitial) ||
+    !isCombatantSnapshot(body.enemyInitial)
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid payload: expected playerInitial, enemyInitial, and numeric seed.' },
+      { status: 400 }
+    );
+  }
+
+  const result = simulateBattle({
+    battleId: randomUUID(),
+    seed: body.seed,
+    playerInitial: body.playerInitial,
+    enemyInitial: body.enemyInitial
+  });
+
+  return NextResponse.json(result);
+}

--- a/app/battle/page.tsx
+++ b/app/battle/page.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+import BattleReplay from '../../components/BattleReplay';
+import type { BattleResult, CombatantSnapshot } from '../../engine/battle/battleEngine';
+
+const playerInitial: CombatantSnapshot = {
+  entityId: 'player-1',
+  hp: 1400,
+  hpMax: 1400,
+  atk: 160,
+  def: 100,
+  spd: 120,
+  accuracyBP: 8500,
+  evadeBP: 1400,
+  activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW']
+};
+
+const enemyInitial: CombatantSnapshot = {
+  entityId: 'enemy-scrap-drone',
+  hp: 1200,
+  hpMax: 1200,
+  atk: 140,
+  def: 90,
+  spd: 110,
+  accuracyBP: 8000,
+  evadeBP: 1200,
+  activeSkillIds: ['VOLT_STRIKE', 'FINISHING_BLOW']
+};
+
+export default function BattlePage() {
+  const [seed, setSeed] = useState(42);
+  const [result, setResult] = useState<BattleResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSimulate = async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('/api/combat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playerInitial,
+          enemyInitial,
+          seed
+        })
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json()) as { error?: string };
+        setError(payload.error ?? 'Combat request failed.');
+        return;
+      }
+
+      const payload = (await response.json()) as BattleResult;
+      setResult(payload);
+    } catch {
+      setError('Unable to reach combat API.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Battle Simulator</h1>
+      <p>Run a deterministic server-side battle and replay the events.</p>
+      <label htmlFor="seed-input">Seed: </label>
+      <input
+        id="seed-input"
+        type="number"
+        value={seed}
+        onChange={(event) => setSeed(Number(event.target.value))}
+      />
+      <button type="button" onClick={onSimulate} disabled={isLoading} style={{ marginLeft: 8 }}>
+        {isLoading ? 'Simulating...' : 'Simulate Battle'}
+      </button>
+
+      {error !== null && <p style={{ color: 'crimson' }}>{error}</p>}
+      {result !== null && <BattleReplay result={result} />}
+    </main>
+  );
+}

--- a/components/BattleReplay.tsx
+++ b/components/BattleReplay.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import type { BattleResult } from '../engine/battle/battleEngine';
+
+type Props = {
+  result: BattleResult;
+};
+
+type HpState = {
+  [entityId: string]: {
+    hp: number;
+    hpMax: number;
+  };
+};
+
+function toLogLine(result: BattleResult, index: number): string {
+  const event = result.events[index];
+
+  switch (event.type) {
+    case 'ROUND_START':
+      return `Round ${event.round} starts`;
+    case 'ACTION':
+      return `${event.actorId} uses ${event.skillId} on ${event.targetId}`;
+    case 'HIT_RESULT':
+      return `${event.actorId} ${event.didHit ? 'hits' : 'misses'} (roll ${event.rollBP} vs ${event.hitChanceBP})`;
+    case 'DAMAGE':
+      return `${event.targetId} takes ${event.amount} damage (HP ${event.targetHpAfter})`;
+    case 'STATUS_APPLY':
+      return `${event.targetId} gains ${event.statusId} (${event.remainingTurns} turns)`;
+    case 'STATUS_REFRESH':
+      return `${event.targetId} refreshes ${event.statusId} (${event.remainingTurns} turns)`;
+    case 'STATUS_EXPIRE':
+      return `${event.targetId} ${event.statusId} expired`;
+    case 'COOLDOWN_SET':
+      return `${event.actorId} sets cooldown on ${event.skillId} to ${event.cooldownRemainingTurns}`;
+    case 'DEATH':
+      return `${event.entityId} is defeated`;
+    case 'ROUND_END':
+      return `Round ${event.round} ends`;
+    case 'BATTLE_END':
+      return `Battle ends. Winner: ${event.winnerEntityId} (${event.reason})`;
+    default:
+      return 'Unknown event';
+  }
+}
+
+export default function BattleReplay({ result }: Props) {
+  const hpState = useMemo<HpState>(() => {
+    const state: HpState = {
+      [result.playerInitial.entityId]: {
+        hp: result.playerInitial.hp,
+        hpMax: result.playerInitial.hpMax
+      },
+      [result.enemyInitial.entityId]: {
+        hp: result.enemyInitial.hp,
+        hpMax: result.enemyInitial.hpMax
+      }
+    };
+
+    for (const event of result.events) {
+      if (event.type === 'DAMAGE') {
+        state[event.targetId] = {
+          ...state[event.targetId],
+          hp: event.targetHpAfter
+        };
+      }
+    }
+
+    return state;
+  }, [result]);
+
+  return (
+    <section>
+      <h2>Battle Replay</h2>
+      <p>Seed: {result.seed}</p>
+      <ul>
+        {Object.entries(hpState).map(([entityId, hp]) => (
+          <li key={entityId}>
+            {entityId}: {hp.hp}/{hp.hpMax}
+            <progress max={hp.hpMax} value={hp.hp} style={{ marginLeft: 8 }} />
+          </li>
+        ))}
+      </ul>
+
+      <ol>
+        {result.events.map((_, index) => (
+          <li key={index}>{toLogLine(result, index)}</li>
+        ))}
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a Day-1 vertical slice implementing a server-authoritative, deterministic 1v1 battle simulation and a client-side replay UI per the SSOT requirements. 

### Description
- Add `POST /api/combat` route (`app/api/combat/route.ts`) that validates `playerInitial`, `enemyInitial`, and numeric `seed`, runs `simulateBattle(...)`, and returns a `BattleResult` JSON; invalid JSON or payloads return `400`.
- Add a minimal battle page (`app/battle/page.tsx`) with hardcoded snapshots, a seed input, and a **Simulate Battle** button that calls the combat API and stores the returned result.
- Add `components/BattleReplay.tsx`, a client component that renders a text event-by-event replay and simple HP bars computed from the returned `events`.
- Wire the UI to the existing deterministic engine (`engine/battle/battleEngine.ts`) so identical seeds produce identical event logs.

### Testing
- Ran the unit test suite with `npm test`, all test suites passed (7 suites, 17 tests) — success.
- Built the Next.js app with `npm run build` which completed successfully (production build compiled without errors) — success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9423b64c08329a47615a97b24e3f7)