### PR TITLE
WO9: add user/character persistence, equip APIs, and basic loadout UI

### DIFF
--- a/app/api/auth/anon/route.ts
+++ b/app/api/auth/anon/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+import { prisma } from '../../../../lib/prisma';
+
+export async function POST() {
+  const user = await prisma.user.create();
+  return NextResponse.json({ userId: user.id }, { status: 201 });
+}

--- a/app/api/character/create/route.ts
+++ b/app/api/character/create/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+
+import { getPassiveDef } from '../../../../engine/battle/passiveRegistry';
+import { getSkillDef } from '../../../../engine/battle/skillRegistry';
+import { prisma } from '../../../../lib/prisma';
+
+type CreateCharacterPayload = {
+  userId: string;
+  name?: string;
+};
+
+const STARTER_ACTIVE_SKILLS = ['VOLT_STRIKE', 'FINISHING_BLOW'];
+const STARTER_PASSIVES = ['EAGLE_EYE', 'EXECUTIONER_FOCUS'];
+
+export async function POST(request: Request) {
+  let body: Partial<CreateCharacterPayload>;
+
+  try {
+    body = (await request.json()) as Partial<CreateCharacterPayload>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (typeof body.userId !== 'string' || body.userId.length === 0) {
+    return NextResponse.json({ error: 'userId is required.' }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique(body.userId);
+  if (user === null) {
+    return NextResponse.json({ error: 'User not found.' }, { status: 404 });
+  }
+
+  const name = typeof body.name === 'string' && body.name.trim().length > 0 ? body.name.trim() : 'Rookie';
+
+  const character = await prisma.character.create({
+    userId: body.userId,
+    name,
+    hp: 1200,
+    hpMax: 1200,
+    atk: 120,
+    def: 70,
+    spd: 100,
+    accuracyBP: 8000,
+    evadeBP: 1200,
+    activeSkills: STARTER_ACTIVE_SKILLS,
+    passiveSkills: STARTER_PASSIVES
+  });
+
+  STARTER_ACTIVE_SKILLS.forEach((skillId) => getSkillDef(skillId));
+  STARTER_PASSIVES.forEach((passiveId) => getPassiveDef(passiveId));
+
+  return NextResponse.json(
+    {
+      characterId: character.id,
+      userId: character.userId,
+      name: character.name,
+      level: character.level,
+      stats: {
+        hp: character.hp,
+        hpMax: character.hpMax,
+        atk: character.atk,
+        def: character.def,
+        spd: character.spd,
+        accuracyBP: character.accuracyBP,
+        evadeBP: character.evadeBP
+      },
+      activeSkills: STARTER_ACTIVE_SKILLS,
+      passiveSkills: STARTER_PASSIVES,
+      unlockedSkillIds: STARTER_ACTIVE_SKILLS
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/character/equip/route.ts
+++ b/app/api/character/equip/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { getPassiveDef } from '../../../../engine/battle/passiveRegistry';
+import { getSkillDef } from '../../../../engine/battle/skillRegistry';
+import { prisma } from '../../../../lib/prisma';
+
+type EquipPayload = {
+  characterId: string;
+  activeSkills: string[];
+  passiveSkills: string[];
+};
+
+function validateUniqueIds(ids: string[]): boolean {
+  return new Set(ids).size === ids.length;
+}
+
+export async function POST(request: Request) {
+  let body: Partial<EquipPayload>;
+
+  try {
+    body = (await request.json()) as Partial<EquipPayload>;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  if (typeof body.characterId !== 'string' || body.characterId.length === 0) {
+    return NextResponse.json({ error: 'characterId is required.' }, { status: 400 });
+  }
+
+  if (
+    !Array.isArray(body.activeSkills) ||
+    !Array.isArray(body.passiveSkills) ||
+    body.activeSkills.length !== 2 ||
+    body.passiveSkills.length !== 2 ||
+    !body.activeSkills.every((skillId) => typeof skillId === 'string') ||
+    !body.passiveSkills.every((passiveId) => typeof passiveId === 'string')
+  ) {
+    return NextResponse.json(
+      { error: 'Payload must include exactly 2 activeSkills and 2 passiveSkills.' },
+      { status: 400 }
+    );
+  }
+
+  if (!validateUniqueIds(body.activeSkills) || !validateUniqueIds(body.passiveSkills)) {
+    return NextResponse.json({ error: 'Skills within each loadout must be unique.' }, { status: 400 });
+  }
+
+  try {
+    body.activeSkills.forEach((skillId) => getSkillDef(skillId));
+    body.passiveSkills.forEach((passiveId) => getPassiveDef(passiveId));
+  } catch {
+    return NextResponse.json({ error: 'Unknown active skill or passive skill.' }, { status: 400 });
+  }
+
+  const character = await prisma.character.findUnique(body.characterId);
+  if (character === null) {
+    return NextResponse.json({ error: 'Character not found.' }, { status: 404 });
+  }
+
+  await prisma.character.updateEquip(body.characterId, body.activeSkills, body.passiveSkills);
+
+  return NextResponse.json({
+    characterId: body.characterId,
+    activeSkills: body.activeSkills,
+    passiveSkills: body.passiveSkills
+  });
+}

--- a/app/api/character/route.ts
+++ b/app/api/character/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+
+import { prisma } from '../../../lib/prisma';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+
+  if (userId === null || userId.length === 0) {
+    return NextResponse.json({ error: 'userId query parameter is required.' }, { status: 400 });
+  }
+
+  const character = await prisma.character.findByUserId(userId);
+
+  if (character === null) {
+    return NextResponse.json({ character: null });
+  }
+
+  return NextResponse.json({
+    character: {
+      characterId: character.id,
+      userId: character.userId,
+      name: character.name,
+      level: character.level,
+      exp: character.exp,
+      stats: {
+        hp: character.hp,
+        hpMax: character.hpMax,
+        atk: character.atk,
+        def: character.def,
+        spd: character.spd,
+        accuracyBP: character.accuracyBP,
+        evadeBP: character.evadeBP
+      },
+      activeSkills: character.activeSkills,
+      passiveSkills: character.passiveSkills,
+      unlockedSkillIds: character.unlockedSkillIds,
+      inventory: character.inventory
+    }
+  });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,186 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+type CharacterResponse = {
+  character: {
+    characterId: string;
+    userId: string;
+    name: string;
+    level: number;
+    exp: number;
+    activeSkills: string[];
+    passiveSkills: string[];
+  } | null;
+};
+
+const ALLOWED_ACTIVE_SKILLS = ['VOLT_STRIKE', 'FINISHING_BLOW'];
+const ALLOWED_PASSIVE_SKILLS = ['EAGLE_EYE', 'EXECUTIONER_FOCUS'];
+
 export default function HomePage() {
-  return <main>Keep Pushing scaffold is ready.</main>;
+  const [userId, setUserId] = useState('');
+  const [characterId, setCharacterId] = useState('');
+  const [name, setName] = useState('Rookie');
+  const [activeSkills, setActiveSkills] = useState<string[]>(['VOLT_STRIKE', 'FINISHING_BLOW']);
+  const [passiveSkills, setPassiveSkills] = useState<string[]>(['EAGLE_EYE', 'EXECUTIONER_FOCUS']);
+  const [status, setStatus] = useState('Idle.');
+
+  const canEquip = useMemo(
+    () => characterId.length > 0 && activeSkills.length === 2 && passiveSkills.length === 2,
+    [activeSkills, characterId, passiveSkills]
+  );
+
+  const createAnonUser = useCallback(async () => {
+    const response = await fetch('/api/auth/anon', { method: 'POST' });
+    const data = (await response.json()) as { userId?: string; error?: string };
+
+    if (!response.ok || data.userId === undefined) {
+      setStatus(data.error ?? 'Could not create anonymous user.');
+      return;
+    }
+
+    setUserId(data.userId);
+    setStatus(`Created anonymous user ${data.userId}`);
+  }, []);
+
+  const createCharacter = useCallback(async () => {
+    const response = await fetch('/api/character/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, name })
+    });
+
+    const data = (await response.json()) as { characterId?: string; error?: string };
+
+    if (!response.ok || data.characterId === undefined) {
+      setStatus(data.error ?? 'Could not create character.');
+      return;
+    }
+
+    setCharacterId(data.characterId);
+    setStatus(`Created character ${data.characterId}`);
+  }, [name, userId]);
+
+  const loadCharacter = useCallback(async () => {
+    const response = await fetch(`/api/character?userId=${encodeURIComponent(userId)}`);
+    const data = (await response.json()) as CharacterResponse & { error?: string };
+
+    if (!response.ok) {
+      setStatus(data.error ?? 'Could not load character.');
+      return;
+    }
+
+    if (data.character === null) {
+      setStatus('No character found for user.');
+      return;
+    }
+
+    setCharacterId(data.character.characterId);
+    setActiveSkills(data.character.activeSkills);
+    setPassiveSkills(data.character.passiveSkills);
+    setStatus(`Loaded character ${data.character.name} (Lv ${data.character.level})`);
+  }, [userId]);
+
+  const equipLoadout = useCallback(async () => {
+    const response = await fetch('/api/character/equip', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ characterId, activeSkills, passiveSkills })
+    });
+
+    const data = (await response.json()) as { error?: string };
+
+    if (!response.ok) {
+      setStatus(data.error ?? 'Could not equip loadout.');
+      return;
+    }
+
+    setStatus('Loadout saved.');
+  }, [activeSkills, characterId, passiveSkills]);
+
+  return (
+    <main style={{ display: 'grid', gap: 12, maxWidth: 560, margin: '2rem auto' }}>
+      <h1>Keep Pushing — Character Setup</h1>
+      <button onClick={createAnonUser} type="button">
+        1) Create Anonymous User
+      </button>
+      <label>
+        User ID
+        <input value={userId} onChange={(event) => setUserId(event.target.value)} />
+      </label>
+      <label>
+        Character Name
+        <input value={name} onChange={(event) => setName(event.target.value)} />
+      </label>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button disabled={userId.length === 0} onClick={createCharacter} type="button">
+          2) Create Character
+        </button>
+        <button disabled={userId.length === 0} onClick={loadCharacter} type="button">
+          Load Character
+        </button>
+      </div>
+
+      <p>Character ID: {characterId || '—'}</p>
+
+      <label>
+        Active Skill 1
+        <select
+          value={activeSkills[0]}
+          onChange={(event) => setActiveSkills([event.target.value, activeSkills[1]])}
+        >
+          {ALLOWED_ACTIVE_SKILLS.map((skillId) => (
+            <option key={`active-1-${skillId}`} value={skillId}>
+              {skillId}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Active Skill 2
+        <select
+          value={activeSkills[1]}
+          onChange={(event) => setActiveSkills([activeSkills[0], event.target.value])}
+        >
+          {ALLOWED_ACTIVE_SKILLS.map((skillId) => (
+            <option key={`active-2-${skillId}`} value={skillId}>
+              {skillId}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Passive Skill 1
+        <select
+          value={passiveSkills[0]}
+          onChange={(event) => setPassiveSkills([event.target.value, passiveSkills[1]])}
+        >
+          {ALLOWED_PASSIVE_SKILLS.map((passiveId) => (
+            <option key={`passive-1-${passiveId}`} value={passiveId}>
+              {passiveId}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Passive Skill 2
+        <select
+          value={passiveSkills[1]}
+          onChange={(event) => setPassiveSkills([passiveSkills[0], event.target.value])}
+        >
+          {ALLOWED_PASSIVE_SKILLS.map((passiveId) => (
+            <option key={`passive-2-${passiveId}`} value={passiveId}>
+              {passiveId}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button disabled={!canEquip} onClick={equipLoadout} type="button">
+        3) Save Equipped Skills
+      </button>
+
+      <p>Status: {status}</p>
+    </main>
+  );
 }

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,159 @@
+import { Pool } from 'pg';
+
+const connectionString = process.env.DATABASE_URL;
+
+const pool = new Pool(
+  connectionString
+    ? {
+        connectionString
+      }
+    : undefined
+);
+
+type CharacterCreateInput = {
+  userId: string;
+  name: string;
+  hp: number;
+  hpMax: number;
+  atk: number;
+  def: number;
+  spd: number;
+  accuracyBP: number;
+  evadeBP: number;
+  activeSkills: string[];
+  passiveSkills: string[];
+};
+
+export const prisma = {
+  user: {
+    async create() {
+      const result = await pool.query<{ id: string }>('INSERT INTO "User" DEFAULT VALUES RETURNING id');
+      return result.rows[0];
+    },
+    async findUnique(id: string) {
+      const result = await pool.query<{ id: string }>('SELECT id FROM "User" WHERE id = $1 LIMIT 1', [id]);
+      return result.rows[0] ?? null;
+    }
+  },
+  character: {
+    async create(input: CharacterCreateInput) {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const characterResult = await client.query<{
+          id: string;
+          userId: string;
+          name: string;
+          level: number;
+          exp: number;
+          hp: number;
+          hpMax: number;
+          atk: number;
+          def: number;
+          spd: number;
+          accuracyBP: number;
+          evadeBP: number;
+        }>(
+          `INSERT INTO "Character"
+            ("userId", "name", "hp", "hpMax", "atk", "def", "spd", "accuracyBP", "evadeBP")
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+          RETURNING id, "userId", name, level, exp, hp, "hpMax", atk, def, spd, "accuracyBP", "evadeBP"`,
+          [input.userId, input.name, input.hp, input.hpMax, input.atk, input.def, input.spd, input.accuracyBP, input.evadeBP]
+        );
+        const character = characterResult.rows[0];
+
+        for (let index = 0; index < input.activeSkills.length; index += 1) {
+          const skillId = input.activeSkills[index];
+          await client.query('INSERT INTO "SkillUnlock" ("characterId", "skillId") VALUES ($1, $2)', [
+            character.id,
+            skillId
+          ]);
+          await client.query(
+            'INSERT INTO "EquippedSkill" ("characterId", slot, "skillId") VALUES ($1, $2, $3)',
+            [character.id, index, skillId]
+          );
+        }
+
+        for (let index = 0; index < input.passiveSkills.length; index += 1) {
+          await client.query(
+            'INSERT INTO "EquippedPassive" ("characterId", slot, "passiveId") VALUES ($1, $2, $3)',
+            [character.id, index, input.passiveSkills[index]]
+          );
+        }
+
+        await client.query('COMMIT');
+        return character;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    },
+    async findByUserId(userId: string) {
+      const characterResult = await pool.query(
+        'SELECT id, "userId", name, level, exp, hp, "hpMax", atk, def, spd, "accuracyBP", "evadeBP" FROM "Character" WHERE "userId" = $1 LIMIT 1',
+        [userId]
+      );
+      const character = characterResult.rows[0];
+      if (character === undefined) {
+        return null;
+      }
+
+      const [skills, passives, unlocks, inventory] = await Promise.all([
+        pool.query('SELECT "skillId" FROM "EquippedSkill" WHERE "characterId" = $1 ORDER BY slot ASC', [
+          character.id
+        ]),
+        pool.query('SELECT "passiveId" FROM "EquippedPassive" WHERE "characterId" = $1 ORDER BY slot ASC', [
+          character.id
+        ]),
+        pool.query('SELECT "skillId" FROM "SkillUnlock" WHERE "characterId" = $1 ORDER BY "unlockedAt" ASC', [
+          character.id
+        ]),
+        pool.query('SELECT "itemId", quantity FROM "InventoryItem" WHERE "characterId" = $1 ORDER BY "itemId" ASC', [
+          character.id
+        ])
+      ]);
+
+      return {
+        ...character,
+        activeSkills: skills.rows.map((row) => row.skillId),
+        passiveSkills: passives.rows.map((row) => row.passiveId),
+        unlockedSkillIds: unlocks.rows.map((row) => row.skillId),
+        inventory: inventory.rows
+      };
+    },
+    async findUnique(id: string) {
+      const result = await pool.query('SELECT id FROM "Character" WHERE id = $1 LIMIT 1', [id]);
+      return result.rows[0] ?? null;
+    },
+    async updateEquip(characterId: string, activeSkills: string[], passiveSkills: string[]) {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query('DELETE FROM "EquippedSkill" WHERE "characterId" = $1', [characterId]);
+        await client.query('DELETE FROM "EquippedPassive" WHERE "characterId" = $1', [characterId]);
+
+        for (let index = 0; index < activeSkills.length; index += 1) {
+          await client.query(
+            'INSERT INTO "EquippedSkill" ("characterId", slot, "skillId") VALUES ($1, $2, $3)',
+            [characterId, index, activeSkills[index]]
+          );
+        }
+        for (let index = 0; index < passiveSkills.length; index += 1) {
+          await client.query(
+            'INSERT INTO "EquippedPassive" ("characterId", slot, "passiveId") VALUES ($1, $2, $3)',
+            [characterId, index, passiveSkills[index]]
+          );
+        }
+
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "keep-pushing",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^7.4.2",
+        "@types/pg": "^8.18.0",
         "next": "14.2.5",
+        "pg": "^8.20.0",
+        "prisma": "^7.4.2",
         "react": "18.3.1",
         "react-dom": "18.3.1"
       },
@@ -541,6 +545,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "10.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
+      "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-socket": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
+      "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "pglite-server": "dist/scripts/server.js"
+      },
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
+      }
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
+      "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.3.15"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -636,6 +700,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1204,6 +1280,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mrleebo/prisma-ast": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
+      "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^10.5.0",
+        "lilconfig": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1436,6 +1525,159 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.4.2"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.4.2.tgz",
+      "integrity": "sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/config": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
+      "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.18.4",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
+      "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
+      "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@electric-sql/pglite": "0.3.15",
+        "@electric-sql/pglite-socket": "0.0.20",
+        "@electric-sql/pglite-tools": "0.2.20",
+        "@hono/node-server": "1.19.9",
+        "@mrleebo/prisma-ast": "0.13.1",
+        "@prisma/get-platform": "7.2.0",
+        "@prisma/query-plan-executor": "7.2.0",
+        "foreground-child": "3.3.1",
+        "get-port-please": "3.2.0",
+        "hono": "4.11.4",
+        "http-status-codes": "2.3.0",
+        "pathe": "2.0.3",
+        "proper-lockfile": "4.1.2",
+        "remeda": "2.33.4",
+        "std-env": "3.10.0",
+        "valibot": "1.2.0",
+        "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
+      "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/fetch-engine": "7.4.2",
+        "@prisma/get-platform": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
+      "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
+      "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/get-platform": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
+      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/query-plan-executor": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
+      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
+      "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1476,6 +1718,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -1608,24 +1856,32 @@
       "version": "20.14.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.12.tgz",
       "integrity": "sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.18.0.tgz",
+      "integrity": "sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2412,6 +2668,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
@@ -2677,6 +2942,34 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2794,6 +3087,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2808,6 +3130,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -2923,6 +3254,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2956,7 +3302,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2971,7 +3316,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3085,6 +3429,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3120,6 +3473,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3167,6 +3541,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3188,6 +3574,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
+      "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -3231,6 +3627,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -3966,6 +4371,34 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4155,7 +4588,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -4231,6 +4663,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -4296,6 +4737,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "license": "MIT"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4352,6 +4799,23 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob": {
@@ -4490,11 +4954,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/grammex": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
+      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "license": "MIT"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graphmatch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
       "license": "MIT"
     },
     "node_modules/has-bigints": {
@@ -4591,11 +5067,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
+      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -4606,6 +5097,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4993,6 +5500,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5162,7 +5675,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -5918,6 +6430,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6071,6 +6592,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6094,6 +6624,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6107,6 +6643,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6128,6 +6670,21 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -6254,6 +6811,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mysql2": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6375,6 +6964,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6411,6 +7006,29 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6534,6 +7152,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6695,7 +7319,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6740,6 +7363,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -6840,6 +7564,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6876,6 +7611,58 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6916,6 +7703,39 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prisma": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
+      "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "7.4.2",
+        "@prisma/dev": "0.20.0",
+        "@prisma/engines": "7.4.2",
+        "@prisma/studio-core": "0.13.1",
+        "mysql2": "3.15.3",
+        "postgres": "3.4.7"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": ">=9.0.0",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6949,6 +7769,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6963,7 +7800,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6997,6 +7833,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -7029,6 +7875,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7052,6 +7911,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7071,6 +7936,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "2.33.4",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
+      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
       }
     },
     "node_modules/require-directory": {
@@ -7155,6 +8029,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -7286,6 +8169,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -7307,6 +8196,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7361,7 +8255,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7374,7 +8267,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7460,7 +8352,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7516,12 +8407,30 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -7552,6 +8461,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7925,6 +8840,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8215,7 +9139,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8248,7 +9172,6 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8342,6 +9265,20 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -8356,7 +9293,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8596,6 +9532,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8675,6 +9620,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeptomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
+      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
+      "license": "MIT",
+      "dependencies": {
+        "grammex": "^3.1.11",
+        "graphmatch": "^1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "test": "jest --runInBand"
   },
   "dependencies": {
+    "@prisma/client": "^7.4.2",
+    "@types/pg": "^8.18.0",
     "next": "14.2.5",
+    "pg": "^8.20.0",
+    "prisma": "^7.4.2",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/prisma/migrations/202603050001_init/migration.sql
+++ b/prisma/migrations/202603050001_init/migration.sql
@@ -1,0 +1,116 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Character" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "level" INTEGER NOT NULL DEFAULT 1,
+    "exp" INTEGER NOT NULL DEFAULT 0,
+    "hp" INTEGER NOT NULL,
+    "hpMax" INTEGER NOT NULL,
+    "atk" INTEGER NOT NULL,
+    "def" INTEGER NOT NULL,
+    "spd" INTEGER NOT NULL,
+    "accuracyBP" INTEGER NOT NULL,
+    "evadeBP" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Character_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SkillUnlock" (
+    "id" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "skillId" TEXT NOT NULL,
+    "unlockedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SkillUnlock_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EquippedSkill" (
+    "id" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "skillId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EquippedSkill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EquippedPassive" (
+    "id" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "passiveId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EquippedPassive_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InventoryItem" (
+    "id" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InventoryItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Character_userId_idx" ON "Character"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SkillUnlock_characterId_skillId_key" ON "SkillUnlock"("characterId", "skillId");
+
+-- CreateIndex
+CREATE INDEX "SkillUnlock_characterId_idx" ON "SkillUnlock"("characterId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EquippedSkill_characterId_slot_key" ON "EquippedSkill"("characterId", "slot");
+
+-- CreateIndex
+CREATE INDEX "EquippedSkill_characterId_idx" ON "EquippedSkill"("characterId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EquippedPassive_characterId_slot_key" ON "EquippedPassive"("characterId", "slot");
+
+-- CreateIndex
+CREATE INDEX "EquippedPassive_characterId_idx" ON "EquippedPassive"("characterId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InventoryItem_characterId_itemId_key" ON "InventoryItem"("characterId", "itemId");
+
+-- CreateIndex
+CREATE INDEX "InventoryItem_characterId_idx" ON "InventoryItem"("characterId");
+
+-- AddForeignKey
+ALTER TABLE "Character" ADD CONSTRAINT "Character_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SkillUnlock" ADD CONSTRAINT "SkillUnlock_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EquippedSkill" ADD CONSTRAINT "EquippedSkill_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EquippedPassive" ADD CONSTRAINT "EquippedPassive_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryItem" ADD CONSTRAINT "InventoryItem_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,89 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id         String      @id @default(cuid())
+  createdAt  DateTime    @default(now())
+  updatedAt  DateTime    @updatedAt
+  characters Character[]
+}
+
+model Character {
+  id               String             @id @default(cuid())
+  userId           String
+  name             String
+  level            Int                @default(1)
+  exp              Int                @default(0)
+  hp               Int
+  hpMax            Int
+  atk              Int
+  def              Int
+  spd              Int
+  accuracyBP       Int
+  evadeBP          Int
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+  user             User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  skillUnlocks     SkillUnlock[]
+  equippedSkills   EquippedSkill[]
+  equippedPassives EquippedPassive[]
+  inventoryItems   InventoryItem[]
+
+  @@index([userId])
+}
+
+model SkillUnlock {
+  id          String    @id @default(cuid())
+  characterId String
+  skillId     String
+  unlockedAt  DateTime  @default(now())
+  character   Character @relation(fields: [characterId], references: [id], onDelete: Cascade)
+
+  @@unique([characterId, skillId])
+  @@index([characterId])
+}
+
+model EquippedSkill {
+  id          String    @id @default(cuid())
+  characterId String
+  slot        Int
+  skillId     String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  character   Character @relation(fields: [characterId], references: [id], onDelete: Cascade)
+
+  @@unique([characterId, slot])
+  @@index([characterId])
+}
+
+model EquippedPassive {
+  id          String    @id @default(cuid())
+  characterId String
+  slot        Int
+  passiveId   String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  character   Character @relation(fields: [characterId], references: [id], onDelete: Cascade)
+
+  @@unique([characterId, slot])
+  @@index([characterId])
+}
+
+model InventoryItem {
+  id          String    @id @default(cuid())
+  characterId String
+  itemId      String
+  quantity    Int       @default(0)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  character   Character @relation(fields: [characterId], references: [id], onDelete: Cascade)
+
+  @@unique([characterId, itemId])
+  @@index([characterId])
+}


### PR DESCRIPTION
### Motivation
- Provide WO9 vertical-slice persistence so users and characters (stats, unlocks, equipped skills/passives, inventory) are stored in Postgres per the SSOT and WO9 acceptance criteria. 
- Expose minimal server-side APIs to create anonymous users, create/load characters, and save validated 2-active/2-passive loadouts. 
- Surface basic UI wiring so the vertical slice can create/load characters and persist equipped skills outside of combat.

### Description
- Add Prisma schema `prisma/schema.prisma` and an initial SQL migration `prisma/migrations/202603050001_init/migration.sql` modeling `User`, `Character`, `SkillUnlock`, `EquippedSkill`, `EquippedPassive`, and `InventoryItem`.
- Implement `lib/prisma.ts` as a lightweight DB access layer using a `pg` connection pool with the minimal operations required by the routes (`user.create`, `character.create`, `character.findByUserId`, `character.findUnique`, `character.updateEquip`).
- Add server route handlers: `POST /api/auth/anon`, `POST /api/character/create`, `GET /api/character`, and `POST /api/character/equip`; the equip route enforces exactly 2 active + 2 passive skills, uniqueness per slot, and validates IDs against the local skill/passive registries before persisting.
- Wire a basic client UI at `app/page.tsx` to create an anonymous user, create/load a character, choose two active and two passive skills, and save the loadout; also add required dependencies (`prisma`, `@prisma/client`, `pg`, `@types/pg`) and updated lockfile entries.

### Testing
- Ran `npm test` and all Jest suites passed (`9` test suites, `19` tests total) with no failures.
- Ran `npm run build` (Next build) and the project compiled and built successfully with server routes collected (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a960fcb3f48329b6643d09f7379d1a)