### PR TITLE
docs: add high-value inline comments across battle engine

### DIFF
--- a/engine/battle/aiDecision.ts
+++ b/engine/battle/aiDecision.ts
@@ -26,6 +26,7 @@ function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
 }
 
 function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot, skillWeights: ArchetypeSkillWeights): number {
+  // Heuristic intentionally starts from base power so every modifier is an additive preference, not a hard rule.
   let score = skill.basePower;
 
   if (skill.skillId !== BASIC_ATTACK_SKILL_ID) {
@@ -42,6 +43,7 @@ function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot, skillWei
   }
 
   if (skill.tags.includes('stun') && target.statuses.includes('stunned')) {
+    // Reapplying stun is heavily penalized to avoid wasting turns on non-stacking control effects.
     score -= WASTED_STUN_PENALTY;
   }
 
@@ -75,6 +77,7 @@ export function chooseAction(
         return b.score - a.score;
       }
 
+      // Lexical tie-break keeps action selection deterministic for replay and test consistency.
       return a.skillId.localeCompare(b.skillId);
     });
 

--- a/engine/battle/applyPassives.ts
+++ b/engine/battle/applyPassives.ts
@@ -62,6 +62,7 @@ function collectFlatModifiers(passiveSkillIds: readonly string[]): PassiveStatMo
     for (const statKey of STAT_KEYS) {
       const delta = passive.flatStats?.[statKey] ?? 0;
       if (delta !== 0) {
+        // Flat modifiers from multiple passives are cumulative; registry balance is responsible for caps.
         acc[statKey] = (acc[statKey] ?? 0) + delta;
       }
     }
@@ -86,6 +87,7 @@ export function applyConditionalPassives(context: AttackContext): {
   target: AttackSnapshot;
   skill: AttackSkill;
 } {
+  // Each triggered conditional modifier is applied in sequence so later passives can build on prior adjustments.
   let actor = { ...context.actor };
   let target = { ...context.target };
   let skill = { ...context.skill };

--- a/engine/battle/battleEngine.ts
+++ b/engine/battle/battleEngine.ts
@@ -63,6 +63,7 @@ export type BattleResult = {
 
 type RuntimeEntity = CombatantSnapshot & { initiative: number; cooldowns: Record<string, number>; statuses: ActiveStatuses };
 
+// Clone snapshots so simulation-side mutations (hp, cooldowns, statuses) never leak into caller-owned inputs.
 function cloneEntity(entity: CombatantSnapshot): CombatantSnapshot {
   const cloned: CombatantSnapshot = {
     ...entity,
@@ -93,6 +94,7 @@ function getActiveStatusIds(entity: RuntimeEntity): StatusId[] {
 }
 
 export function simulateBattle(input: BattleInput): BattleResult {
+  // The RNG is seeded once per battle to guarantee deterministic replays from the same input payload.
   const rng = new XorShift32(input.seed);
   const maxRounds = input.maxRounds ?? 30;
   const events: BattleEvent[] = [];
@@ -134,6 +136,7 @@ export function simulateBattle(input: BattleInput): BattleResult {
       }
 
       actor.initiative -= 100;
+      // Action cost is always consumed even on control-loss turns, preventing stunned actors from stockpiling turns.
 
       if ((actor.statuses.stunned ?? 0) > 0) {
         events.push({
@@ -160,6 +163,7 @@ export function simulateBattle(input: BattleInput): BattleResult {
       });
 
       if (selectedSkill.skillId !== BASIC_ATTACK_SKILL_ID) {
+        // Cooldown is set before attack resolution so misses still pay the intended opportunity cost.
         actor.cooldowns[selectedSkill.skillId] = selectedSkill.cooldownTurns;
         events.push({
           type: 'COOLDOWN_SET',
@@ -199,6 +203,7 @@ export function simulateBattle(input: BattleInput): BattleResult {
         });
 
         for (const statusId of selectedSkill.appliesStatusIds ?? []) {
+          // Status side effects are hit-gated by design: on-hit riders do not trigger on misses.
           events.push(applyStatus(target.statuses, statusId, actor.entityId, target.entityId, round));
         }
 
@@ -213,6 +218,7 @@ export function simulateBattle(input: BattleInput): BattleResult {
 
     decrementCooldowns(player);
     decrementCooldowns(enemy);
+    // Status durations are decremented after all actions so a newly applied status always survives through the next round.
     events.push(...decrementStatusesAtRoundEnd(player.statuses, player.entityId, round));
     events.push(...decrementStatusesAtRoundEnd(enemy.statuses, enemy.entityId, round));
     events.push({ type: 'ROUND_END', round });

--- a/engine/battle/initiative.ts
+++ b/engine/battle/initiative.ts
@@ -14,6 +14,7 @@ function compareTurnOrder(a: InitiativeCombatant, b: InitiativeCombatant): numbe
     return b.spd - a.spd;
   }
 
+  // Entity id tie-breaker ensures strict deterministic ordering when stats are identical.
   return a.entityId.localeCompare(b.entityId);
 }
 
@@ -47,5 +48,6 @@ export function timeoutWinner(a: InitiativeCombatant, b: InitiativeCombatant): I
     return a.initiative > b.initiative ? a : b;
   }
 
+  // Final deterministic tie-break keeps timeout outcomes stable across runs and environments.
   return a.entityId.localeCompare(b.entityId) <= 0 ? a : b;
 }

--- a/engine/battle/resolveStatus.ts
+++ b/engine/battle/resolveStatus.ts
@@ -29,6 +29,7 @@ export function applyStatus(
   const nextRemainingTurns = statusDef.durationTurns;
   const hadStatus = (statuses[statusId] ?? 0) > 0;
 
+  // Reapplying a status refreshes duration instead of stacking intensity to keep effects predictable.
   statuses[statusId] = nextRemainingTurns;
 
   return {
@@ -48,6 +49,7 @@ export function decrementStatusesAtRoundEnd(
 ): StatusExpireEvent[] {
   const expires: StatusExpireEvent[] = [];
 
+  // Stable ordering keeps emitted STATUS_EXPIRE events deterministic for snapshot-based tests and replays.
   const orderedStatusIds = Object.keys(statuses).sort() as StatusId[];
   for (const statusId of orderedStatusIds) {
     const remainingTurns = statuses[statusId] ?? 0;


### PR DESCRIPTION
### Motivation

- Improve maintainability by documenting non-obvious design decisions and invariants in the battle simulation code.
- Clarify deterministic ordering, status semantics, cooldown/timing expectations, and AI scoring heuristics so future changes avoid regressions.

### Description

- Inserted intent-focused inline comments in `engine/battle/battleEngine.ts` explaining RNG seeding, initiative spending on stunned turns, cooldown timing semantics, hit-gated status application, and end-of-round status decrement ordering.
- Added explanatory comments in `engine/battle/resolveStatus.ts` clarifying that reapplying a status refreshes duration (not stacking) and that expiration processing is sorted for deterministic event output.
- Added deterministic tie-break rationale comments in `engine/battle/initiative.ts` for turn-order and `timeoutWinner` tie-breaking.
- Documented heuristic design, anti-wasted-stun logic, and lexical tie-break determinism in `engine/battle/aiDecision.ts` and annotated passive aggregation and sequential conditional application in `engine/battle/applyPassives.ts`.
- All changes are comments only and do not modify executable code or program logic.

### Testing

- Ran `npm test -- --runTestsByPath tests/battleEngine.skills.test.ts tests/passives.test.ts` and all tests passed (`Test Suites: 2 passed, 2 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9a0244188329b21a9f597167c3fd)