### PR TITLE
docs: add TSDoc comments for combat status registry APIs

### DIFF
--- a/engine/battle/statusRegistry.ts
+++ b/engine/battle/statusRegistry.ts
@@ -1,7 +1,21 @@
+/**
+ * Enumerates every status effect identifier supported by the combat engine.
+ *
+ * These identifiers are used as stable keys for lookup, serialization, and
+ * status application logic across battle systems.
+ */
 export type StatusId = 'stunned' | 'shielded' | 'broken_armor' | 'silenced' | 'resist';
 
+/**
+ * Describes the canonical configuration for a status effect.
+ *
+ * Each definition encodes immutable metadata used by combat resolution, such
+ * as how long the status should remain active once applied.
+ */
 export type StatusDef = {
+  /** Unique registry key for the status definition. */
   id: StatusId;
+  /** Number of turns the status persists before expiring. */
   durationTurns: number;
 };
 
@@ -13,6 +27,15 @@ const STATUS_REGISTRY: Record<StatusId, StatusDef> = {
   resist: { id: 'resist', durationTurns: 3 }
 };
 
+/**
+ * Retrieves the immutable definition for a known status effect.
+ *
+ * This function assumes {@link statusId} is a valid member of {@link StatusId}
+ * and returns the corresponding entry from the in-memory status registry.
+ *
+ * @param statusId - Identifier of the status whose configuration is needed.
+ * @returns The canonical status definition associated with the provided ID.
+ */
 export function getStatusDef(statusId: StatusId): StatusDef {
   return STATUS_REGISTRY[statusId];
 }


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by providing TSDoc hover documentation for the exported status registry APIs so IDEs show intent, assumptions, and usage when these symbols are imported.

### Description
- Inserted TSDoc comments for exported symbols in `engine/battle/statusRegistry.ts`, documenting `StatusId`, `StatusDef` (including field-level docs for `id` and `durationTurns`), and `getStatusDef`; only comments were added and no executable code was modified.

### Testing
- Ran `npm test -- tests/statuses.test.ts` which executed the status tests and all tests passed (3 tests, 1 suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2f17c3388329afbaf6fbf811ea9b)