### PR TITLE
docs: add comprehensive TSDoc to combat resolver modules

### DIFF
--- a/engine/battle/resolveDamage.ts
+++ b/engine/battle/resolveDamage.ts
@@ -1,5 +1,11 @@
 import { XorShift32 } from '../rng/xorshift32';
 
+/**
+ * Minimal actor/target stat projection required to resolve a single attack.
+ *
+ * Resolver call sites pass this reduced shape so hit and damage math stays
+ * decoupled from larger runtime entity objects.
+ */
 export type AttackSnapshot = {
   entityId: string;
   atk: number;
@@ -8,12 +14,24 @@ export type AttackSnapshot = {
   evadeBP: number;
 };
 
+/**
+ * Immutable attack-skill parameters consumed by hit and damage calculations.
+ *
+ * Values are interpreted in basis points where applicable to keep combat math
+ * deterministic and free from floating-point rounding drift.
+ */
 export type AttackSkill = {
   skillId: string;
   basePower: number;
   accuracyModBP: number;
 };
 
+/**
+ * Deterministic result payload produced when resolving one attack attempt.
+ *
+ * The payload includes both intermediate roll/chance values and final damage
+ * so callers can emit complete replay and debugging events.
+ */
 export type AttackResolution = {
   rollBP: number;
   hitChanceBP: number;
@@ -24,20 +42,71 @@ export type AttackResolution = {
 const MIN_HIT_BP = 500;
 const MAX_HIT_BP = 9500;
 
+/**
+ * Clamps a numeric value into an inclusive range.
+ *
+ * This helper is used by combat math to enforce safety bounds on derived
+ * percentages before they are consumed by random rolls.
+ *
+ * @param value - Raw numeric value to constrain.
+ * @param min - Inclusive lower bound.
+ * @param max - Inclusive upper bound.
+ * @returns The bounded value, never lower than {@link min} or higher than {@link max}.
+ */
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+/**
+ * Computes final hit chance in basis points for an attack attempt.
+ *
+ * The formula combines actor accuracy, target evasion, and skill modifiers,
+ * then clamps to global floor/ceiling values so outcomes remain plausible and
+ * no attack becomes strictly guaranteed or impossible.
+ *
+ * @param actor - Acting unit snapshot providing accuracy stats.
+ * @param target - Defending unit snapshot providing evade stats.
+ * @param skill - Selected skill accuracy modifier.
+ * @returns Hit probability in basis points, constrained to the resolver bounds.
+ */
 export function calculateHitChanceBP(actor: AttackSnapshot, target: AttackSnapshot, skill: AttackSkill): number {
   return clamp(actor.accuracyBP - target.evadeBP + skill.accuracyModBP, MIN_HIT_BP, MAX_HIT_BP);
 }
 
+/**
+ * Calculates on-hit damage for a resolved attack.
+ *
+ * The damage model applies defense mitigation using an integer-only formula and
+ * enforces a minimum damage floor of 1 so successful hits always have impact.
+ *
+ * @param actor - Acting unit snapshot providing attack stat.
+ * @param target - Defending unit snapshot providing defense stat.
+ * @param skill - Selected skill base power contribution.
+ * @returns Final integer damage amount to subtract from target HP.
+ */
 export function calculateDamage(actor: AttackSnapshot, target: AttackSnapshot, skill: AttackSkill): number {
   const raw = skill.basePower + actor.atk;
   const damage = Math.floor((raw * 100) / (100 + target.def));
   return Math.max(1, damage);
 }
 
+/**
+ * Resolves a complete attack attempt, including hit roll and conditional damage.
+ *
+ * This function is pure with respect to combat state and does not mutate actor
+ * or target snapshots. Callers are responsible for applying returned damage and
+ * downstream side effects such as status riders.
+ *
+ * Assumptions:
+ * - {@link rng} is seeded externally for deterministic replay behavior.
+ * - Basis-point conventions are used for both hit chance and roll domains.
+ *
+ * @param actor - Acting unit snapshot used for attack and accuracy values.
+ * @param target - Defending unit snapshot used for defense and evasion values.
+ * @param skill - Skill parameters that define power and accuracy behavior.
+ * @param rng - Battle RNG used to sample a 1..10000 hit roll.
+ * @returns Structured attack resolution including whether the hit connected.
+ */
 export function resolveAttack(
   actor: AttackSnapshot,
   target: AttackSnapshot,

--- a/engine/battle/resolveStatus.ts
+++ b/engine/battle/resolveStatus.ts
@@ -1,7 +1,19 @@
 import { getStatusDef, type StatusId } from './statusRegistry';
 
+/**
+ * Mutable map of active status effects to their remaining durations.
+ *
+ * A missing key or non-positive value indicates the status is not currently
+ * active on the entity.
+ */
 export type ActiveStatuses = Partial<Record<StatusId, number>>;
 
+/**
+ * Event emitted when a status is first applied or its duration is refreshed.
+ *
+ * Consumers can use the discriminated {@link type} field to distinguish initial
+ * application from a reapply that resets remaining turns.
+ */
 export type StatusApplyEvent = {
   type: 'STATUS_APPLY' | 'STATUS_REFRESH';
   round: number;
@@ -11,6 +23,9 @@ export type StatusApplyEvent = {
   remainingTurns: number;
 };
 
+/**
+ * Event emitted when an active status naturally expires at round end.
+ */
 export type StatusExpireEvent = {
   type: 'STATUS_EXPIRE';
   round: number;
@@ -18,6 +33,21 @@ export type StatusExpireEvent = {
   statusId: StatusId;
 };
 
+/**
+ * Applies or refreshes a status on a target status map.
+ *
+ * This function mutates {@link statuses} in place by writing the configured
+ * duration for {@link statusId}. Reapplications refresh remaining turns rather
+ * than stacking effect intensity.
+ *
+ * @param statuses - Mutable status-turn map for the target entity.
+ * @param statusId - Status identifier to apply.
+ * @param sourceId - Entity ID that caused the status application.
+ * @param targetId - Entity ID receiving the status.
+ * @param round - Current simulation round used for event metadata.
+ * @returns A status lifecycle event describing apply versus refresh behavior.
+ * @throws If {@link statusId} is not defined in the status registry.
+ */
 export function applyStatus(
   statuses: ActiveStatuses,
   statusId: StatusId,
@@ -42,6 +72,18 @@ export function applyStatus(
   };
 }
 
+/**
+ * Advances status durations at round end and emits expiration events.
+ *
+ * The provided {@link statuses} map is mutated in place: expired entries are
+ * deleted and surviving entries are decremented by one turn. Expiration events
+ * are emitted in stable key order for deterministic replay output.
+ *
+ * @param statuses - Mutable status-turn map for one combatant.
+ * @param targetId - Entity ID owning the status map.
+ * @param round - Current simulation round used for event metadata.
+ * @returns Ordered list of expiration events generated during the decrement pass.
+ */
 export function decrementStatusesAtRoundEnd(
   statuses: ActiveStatuses,
   targetId: string,


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by providing rich TSDoc comments so IDE hovers on resolver symbols show clear purpose, behavior, assumptions, and usage.  
- Keep resolver surface well-documented for replay/debugging and to make exported contracts (events, snapshots, resolutions) explicit to callers.

### Description
- Added TSDoc block comments only (no code changes) to `engine/battle/resolveDamage.ts` and `engine/battle/resolveStatus.ts`.  
- Documented exported types and functions in `resolveDamage.ts`: `AttackSnapshot`, `AttackSkill`, `AttackResolution`, `clamp`, `calculateHitChanceBP`, `calculateDamage`, and `resolveAttack`, including behavior, assumptions, side-effects, and `@param`/`@returns` tags.  
- Documented exported types and functions in `resolveStatus.ts`: `ActiveStatuses`, `StatusApplyEvent`, `StatusExpireEvent`, `applyStatus`, and `decrementStatusesAtRoundEnd`, including mutation semantics, ordering guarantees, and `@throws` where relevant.  
- Confirmed comments placed directly above declarations and that only TSDoc blocks were inserted to preserve all executable code, formatting, imports, and existing comments.

### Testing
- Ran the full test suite with `npm test -- --runInBand`.  
- Result: all test suites passed (`9` suites, `19` tests), indicating no behavioral changes were introduced by the documentation-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2f2dca988329890d9bdc6ad89a8b)