### PR TITLE
docs: add TSDoc for combat AI decision and learning modules

### DIFF
--- a/engine/battle/aiDecision.ts
+++ b/engine/battle/aiDecision.ts
@@ -2,12 +2,23 @@ import { BASIC_ATTACK_SKILL_ID, getSkillDef, type SkillDef } from './skillRegist
 import type { StatusId } from './statusRegistry';
 import { scoreLearnedWeightTerm, type ArchetypeSkillWeights } from './learning';
 
+/**
+ * Read-only combat snapshot used by the AI scorer when evaluating candidate skills.
+ *
+ * This shape intentionally contains only data required by heuristics so decision-making
+ * remains deterministic and independent from mutable battle engine state.
+ */
 export type DecisionCombatantSnapshot = {
   hp: number;
   hpMax: number;
   statuses: readonly StatusId[];
 };
 
+/**
+ * Action selected by the AI decision phase.
+ *
+ * The battle engine resolves the referenced skill as the actor's next command.
+ */
 export type CandidateAction = {
   skillId: string;
 };
@@ -17,6 +28,9 @@ const EXECUTE_BONUS = 500;
 const SHIELDBREAK_BONUS = 350;
 const WASTED_STUN_PENALTY = 10_000;
 
+/**
+ * Converts current HP into basis points to avoid floating-point comparisons in heuristics.
+ */
 function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
   if (combatant.hpMax <= 0) {
     return 0;
@@ -25,6 +39,12 @@ function hpPercentBP(combatant: DecisionCombatantSnapshot): number {
   return Math.floor((combatant.hp * 10000) / combatant.hpMax);
 }
 
+/**
+ * Computes a deterministic priority score for a skill against the current target snapshot.
+ *
+ * The score combines static skill power, context-sensitive tag bonuses/penalties,
+ * and learned archetype preferences.
+ */
 function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot, skillWeights: ArchetypeSkillWeights): number {
   // Heuristic intentionally starts from base power so every modifier is an additive preference, not a hard rule.
   let score = skill.basePower;
@@ -56,6 +76,22 @@ function scoreSkill(skill: SkillDef, target: DecisionCombatantSnapshot, skillWei
   return score;
 }
 
+/**
+ * Chooses the next skill the actor should use against the current target.
+ *
+ * The selector always includes the basic attack and only includes active skills whose
+ * cooldown is currently zero. Candidate skills are scored deterministically; when scores
+ * tie, lexical ordering is used so replay output and test runs remain stable.
+ *
+ * This function does not mutate cooldown state or battle entities.
+ *
+ * @param actorActiveSkillIds - The actor's equipped active skill identifiers.
+ * @param actorCooldowns - Remaining cooldown turns keyed by skill identifier.
+ * @param target - Read-only snapshot of the current enemy target.
+ * @param skillWeights - Learned per-skill preference weights for the actor archetype.
+ * @returns The single highest-priority action candidate.
+ * @throws If a candidate skill identifier has no registered definition.
+ */
 export function chooseAction(
   actorActiveSkillIds: readonly [string, string],
   actorCooldowns: Record<string, number>,

--- a/engine/battle/learning.ts
+++ b/engine/battle/learning.ts
@@ -1,30 +1,80 @@
 import type { BattleEvent } from './battleEngine';
 
+/**
+ * Lower saturation bound applied to learned skill preference values.
+ */
 export const MIN_LEARNING_WEIGHT = -1000;
+/**
+ * Upper saturation bound applied to learned skill preference values.
+ */
 export const MAX_LEARNING_WEIGHT = 1000;
+/**
+ * Default per-match adjustment strength used when updating skill weights.
+ */
 export const DEFAULT_LEARNING_RATE = 150;
 
+/**
+ * Persistent preference weights keyed by skill identifier for a combat archetype.
+ *
+ * Positive values increase AI selection score, while negative values suppress usage.
+ */
 export type ArchetypeSkillWeights = Record<string, number>;
 
+/**
+ * Aggregated impact metrics attributed to one skill over a battle.
+ */
 export type SkillContribution = {
   damageDealt: number;
   statusTurnsApplied: number;
 };
 
+/**
+ * Per-skill contribution map derived from battle event history.
+ */
 export type SkillContributions = Record<string, SkillContribution>;
 
+/**
+ * Clamps a weight value into the supported learning range.
+ */
 function clampWeight(weight: number): number {
   return Math.min(MAX_LEARNING_WEIGHT, Math.max(MIN_LEARNING_WEIGHT, weight));
 }
 
+/**
+ * Reads a learned weight for a skill and normalizes it to valid bounds.
+ *
+ * Missing entries are treated as neutral preference.
+ *
+ * @param skillWeights - Stored archetype weight table.
+ * @param skillId - Skill identifier to look up.
+ * @returns The clamped learned preference for the requested skill.
+ */
 export function getLearnedWeight(skillWeights: ArchetypeSkillWeights, skillId: string): number {
   return clampWeight(skillWeights[skillId] ?? 0);
 }
 
+/**
+ * Produces the additive AI scoring term contributed by learned preference data.
+ *
+ * @param skillWeights - Stored archetype weight table.
+ * @param skillId - Skill identifier being scored.
+ * @returns The clamped score modifier to add to heuristic skill scoring.
+ */
 export function scoreLearnedWeightTerm(skillWeights: ArchetypeSkillWeights, skillId: string): number {
   return getLearnedWeight(skillWeights, skillId);
 }
 
+/**
+ * Reconstructs per-skill performance contributions from an actor's battle events.
+ *
+ * Damage and applied-status turns are attributed to the most recent ACTION event
+ * emitted by each actor, which assumes subsequent DAMAGE/STATUS events were caused
+ * by that selected skill.
+ *
+ * @param events - Ordered battle event stream from a completed or partial match.
+ * @param actorId - Actor whose skill contributions should be extracted.
+ * @returns Contribution totals keyed by skill identifier.
+ */
 export function buildSkillContributions(events: readonly BattleEvent[], actorId: string): SkillContributions {
   const contributions: SkillContributions = {};
   const latestActionSkillByActor: Record<string, string> = {};
@@ -56,6 +106,23 @@ export function buildSkillContributions(events: readonly BattleEvent[], actorId:
   return contributions;
 }
 
+/**
+ * Updates learned skill preferences using normalized battle contributions and outcome.
+ *
+ * Each contributing skill receives a signed adjustment derived from dealt damage and
+ * applied status duration. Winning increases preference and losing decreases it.
+ * Updated weights are clamped into the configured learning bounds.
+ *
+ * This function is pure and returns a new weight map.
+ *
+ * @param params - Update inputs including current weights, contributions, and match context.
+ * @param params.currentSkillWeights - Existing learned weights for the archetype.
+ * @param params.skillContributions - Per-skill contribution totals from the battle.
+ * @param params.enemyHpMax - Enemy maximum HP used to normalize damage influence.
+ * @param params.didWin - Whether the actor won the battle.
+ * @param params.learningRate - Optional override for adjustment intensity.
+ * @returns A new skill-weight map with applied learning deltas.
+ */
 export function updateSkillWeights(params: {
   currentSkillWeights: ArchetypeSkillWeights;
   skillContributions: SkillContributions;


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by providing precise TSDoc comments so IDE hovers on AI and learning APIs explain purpose, behavior, assumptions, and usage.
- Make decision and learning invariants explicit (determinism, clamping ranges, event attribution) to reduce misuse when integrating with the battle engine.

### Description
- Added TSDoc comments to exported decision module symbols in `engine/battle/aiDecision.ts`, including `DecisionCombatantSnapshot`, `CandidateAction`, and `chooseAction`, and documented deterministic scoring behavior and tie-breaking rules.
- Added TSDoc comments to internal decision helpers `hpPercentBP` and `scoreSkill` to clarify HP normalization and heuristic composition without changing logic.
- Added TSDoc comments to exported learning module symbols in `engine/battle/learning.ts`, including `MIN_LEARNING_WEIGHT`, `MAX_LEARNING_WEIGHT`, `DEFAULT_LEARNING_RATE`, `ArchetypeSkillWeights`, `SkillContribution`, `SkillContributions`, `getLearnedWeight`, `scoreLearnedWeightTerm`, `buildSkillContributions`, and `updateSkillWeights` and documented clamping, contribution attribution, and update semantics.
- Added short TSDoc for the internal helper `clampWeight`; all edits are documentation-only and do not modify executable code, imports, formatting, or control flow.

### Testing
- Ran targeted Jest suites with `npm test -- --runInBand tests/learning.test.ts tests/battleEngine.skills.test.ts` and both suites passed.
- No runtime or behavioral changes were introduced by these documentation-only edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2f4ee9408329bc83ac26f0426147)