### PR TITLE
docs: add comprehensive TSDoc for initiative module exports

### DIFF
--- a/engine/battle/initiative.ts
+++ b/engine/battle/initiative.ts
@@ -1,3 +1,10 @@
+/**
+ * Represents mutable per-combatant state used by initiative resolution.
+ *
+ * Consumers are expected to keep these values in sync with the broader combat model,
+ * especially the invariant that `hp <= 0` indicates an actor that cannot gain initiative
+ * or take turns.
+ */
 export type InitiativeCombatant = {
   entityId: string;
   spd: number;
@@ -18,6 +25,15 @@ function compareTurnOrder(a: InitiativeCombatant, b: InitiativeCombatant): numbe
   return a.entityId.localeCompare(b.entityId);
 }
 
+/**
+ * Advances initiative for all living combatants by one round-equivalent step.
+ *
+ * This function mutates the provided combatant objects in place. Defeated combatants
+ * (`hp <= 0`) are intentionally skipped so they cannot re-enter turn order.
+ *
+ * @param combatants - Mutable combatant records participating in initiative tracking.
+ * @returns Nothing.
+ */
 export function applyRoundInitiative(combatants: InitiativeCombatant[]): void {
   for (const combatant of combatants) {
     if (combatant.hp > 0) {
@@ -26,10 +42,29 @@ export function applyRoundInitiative(combatants: InitiativeCombatant[]): void {
   }
 }
 
+/**
+ * Indicates whether at least one living combatant is eligible to act immediately.
+ *
+ * Eligibility requires both positive HP and initiative at or above the action threshold
+ * of `100`, matching the same readiness rule used by turn selection.
+ *
+ * @param combatants - Combatant records to evaluate.
+ * @returns `true` when any combatant can act now; otherwise `false`.
+ */
 export function hasReadyActor(combatants: InitiativeCombatant[]): boolean {
   return combatants.some((combatant) => combatant.hp > 0 && combatant.initiative >= 100);
 }
 
+/**
+ * Selects the index of the next acting combatant using deterministic turn-order rules.
+ *
+ * Only living, ready combatants are considered. Ordering is resolved by highest
+ * initiative, then highest speed, then lexicographic entity id to keep results stable
+ * across runtimes when stats are tied.
+ *
+ * @param combatants - Combatant list whose original indices are preserved for the result.
+ * @returns The original array index of the next actor, or `-1` when no actor is ready.
+ */
 export function nextActorIndex(combatants: InitiativeCombatant[]): number {
   const ordered = combatants
     .map((combatant, index) => ({ combatant, index }))
@@ -39,6 +74,16 @@ export function nextActorIndex(combatants: InitiativeCombatant[]): number {
   return ordered.length === 0 ? -1 : ordered[0].index;
 }
 
+/**
+ * Resolves a deterministic winner when combat ends due to timeout.
+ *
+ * The winner is chosen by higher HP, then higher initiative, then lexicographically
+ * lower entity id as a final deterministic tiebreaker.
+ *
+ * @param a - First timeout candidate.
+ * @param b - Second timeout candidate.
+ * @returns The combatant that wins timeout resolution.
+ */
 export function timeoutWinner(a: InitiativeCombatant, b: InitiativeCombatant): InitiativeCombatant {
   if (a.hp !== b.hp) {
     return a.hp > b.hp ? a : b;


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by providing rich TSDoc comments so IDE hovers on initiative APIs explain purpose, assumptions, side effects, and deterministic ordering rules.
- Constrain changes to documentation only so runtime behavior and formatting remain unchanged.

### Description
- Added TSDoc for the exported `InitiativeCombatant` type to describe domain meaning, lifecycle expectations, and the `hp <= 0` invariant.
- Added TSDoc for all exported functions in `engine/battle/initiative.ts`: `applyRoundInitiative`, `hasReadyActor`, `nextActorIndex`, and `timeoutWinner`, documenting behavior, in-place mutation where applicable, deterministic tie-break rules, parameters, and return values.
- Left internal helper `compareTurnOrder` unchanged except for its existing inline tie-break comment, since it was already clear and un-exported.

### Testing
- Ran `npm test -- --runTestsByPath engine/battle/initiative.ts`, which reported no matching tests and exited with code 1 because Jest found no test file at that path.
- Ran `npm test -- --passWithNoTests`, which executed the full test suite and passed (all test suites and tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2f60df28832984e762aee59078fc)