### PR TITLE
docs: add comprehensive TSDoc for skill and passive registries

### DIFF
--- a/engine/battle/passiveRegistry.ts
+++ b/engine/battle/passiveRegistry.ts
@@ -1,13 +1,37 @@
+/**
+ * Stat keys that can be modified by passive effects.
+ *
+ * These keys map to the combatant stat surface used by battle calculations
+ * and allow passives to apply flat adjustments to actor or target values.
+ */
 export type PassiveStatKey = 'hp' | 'hpMax' | 'atk' | 'def' | 'spd' | 'accuracyBP' | 'evadeBP';
 
+/**
+ * Sparse map of passive-driven stat adjustments.
+ *
+ * Only specified keys are modified; omitted keys are treated as unchanged
+ * by passive application logic.
+ */
 export type PassiveStatModifiers = Partial<Record<PassiveStatKey, number>>;
 
+/**
+ * Predicate that gates a conditional passive modifier.
+ *
+ * Conditions are evaluated at runtime against battle context to determine
+ * whether associated bonus modifiers should be applied.
+ */
 export type PassiveCondition =
   | {
       kind: 'target_hp_below_bp';
       thresholdBP: number;
     };
 
+/**
+ * Conditional passive effect bundle applied when its predicate matches.
+ *
+ * Modifiers can affect actor stats, target stats, and skill-specific
+ * accuracy adjustments during combat resolution.
+ */
 export type ConditionalPassiveModifier = {
   when: PassiveCondition;
   actorStats?: PassiveStatModifiers;
@@ -15,6 +39,12 @@ export type ConditionalPassiveModifier = {
   skillAccuracyModBP?: number;
 };
 
+/**
+ * Registry definition for a passive ability.
+ *
+ * A passive can contribute unconditional flat stat modifiers and/or a
+ * collection of conditional effects activated by combat state checks.
+ */
 export type PassiveDef = {
   passiveId: string;
   flatStats?: PassiveStatModifiers;
@@ -42,6 +72,17 @@ const PASSIVE_REGISTRY: Record<string, PassiveDef> = {
   }
 };
 
+/**
+ * Resolves a passive definition by its identifier.
+ *
+ * The passive registry is expected to be authoritative for all passive IDs
+ * referenced by gameplay data. Unknown IDs indicate invalid configuration
+ * and are rejected with an error.
+ *
+ * @param passiveId - Unique passive identifier to resolve from the registry.
+ * @returns The passive definition associated with the provided identifier.
+ * @throws Error if the passive identifier is unknown.
+ */
 export function getPassiveDef(passiveId: string): PassiveDef {
   const passive = PASSIVE_REGISTRY[passiveId];
   if (passive === undefined) {

--- a/engine/battle/skillRegistry.ts
+++ b/engine/battle/skillRegistry.ts
@@ -1,7 +1,19 @@
 import type { StatusId } from './statusRegistry';
 
+/**
+ * Tags that encode special runtime handling for a skill.
+ *
+ * These tags drive downstream combat logic such as execute checks,
+ * stun application behavior, and shield-breaking interactions.
+ */
 export type SkillTag = 'execute' | 'stun' | 'shieldbreak';
 
+/**
+ * Canonical skill definition consumed by battle resolution systems.
+ *
+ * Each entry describes immutable tuning values for power, accuracy,
+ * cooldown behavior, and optional status or execute semantics.
+ */
 export type SkillDef = {
   skillId: string;
   basePower: number;
@@ -12,6 +24,12 @@ export type SkillDef = {
   appliesStatusIds?: StatusId[];
 };
 
+/**
+ * Stable identifier for the default attack skill.
+ *
+ * This constant is used by systems that need a guaranteed fallback
+ * action when no specialized skill is selected.
+ */
 export const BASIC_ATTACK_SKILL_ID = 'BASIC_ATTACK';
 
 const BASIC_ATTACK: SkillDef = {
@@ -48,6 +66,17 @@ const SKILL_REGISTRY: Record<string, SkillDef> = {
   [FINISHING_BLOW.skillId]: FINISHING_BLOW
 };
 
+/**
+ * Resolves a skill definition by its identifier.
+ *
+ * The registry is assumed to contain all valid skill IDs used by the
+ * combat pipeline. A missing entry indicates an invalid or out-of-sync
+ * skill reference and is treated as a hard error.
+ *
+ * @param skillId - Unique skill identifier to resolve from the registry.
+ * @returns The immutable skill definition associated with the provided ID.
+ * @throws Error if the skill identifier is unknown.
+ */
 export function getSkillDef(skillId: string): SkillDef {
   const skill = SKILL_REGISTRY[skillId];
   if (skill === undefined) {


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by providing IDE hover documentation for the exported skill and passive registry APIs so callers understand purpose, invariants, and failure modes.
- Ensure consumers of `getSkillDef` and `getPassiveDef` have clear guidance on assumptions and errors to reduce misuse during battle resolution.

### Description
- Added TSDoc block comments to `engine/battle/skillRegistry.ts` covering `SkillTag`, `SkillDef`, `BASIC_ATTACK_SKILL_ID`, and `getSkillDef` with `@param`, `@returns`, and `@throws` annotations.
- Added TSDoc block comments to `engine/battle/passiveRegistry.ts` covering `PassiveStatKey`, `PassiveStatModifiers`, `PassiveCondition`, `ConditionalPassiveModifier`, `PassiveDef`, and `getPassiveDef` with `@param`, `@returns`, and `@throws` annotations.
- Only non-executable TSDoc comments were inserted; no code, formatting, imports, names, ordering, or logic were changed.

### Testing
- Ran the test suite with `npm test` (Jest) and all test suites passed.
- Test run: 9 test suites, 19 tests, 1 snapshot — all passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac30201ee08329b1e69ae41e274a71)