### PR TITLE
Add settlement batch validation implementation, types, tests, and update MVP plan docs

### DIFF
--- a/docs/solana-battle-outcome-validation-mvp-unified-plan.md
+++ b/docs/solana-battle-outcome-validation-mvp-unified-plan.md
@@ -461,3 +461,137 @@ Before implementation begins, explicitly resolve and record answers for the foll
 2. Decide if `BattleSettlementBatchReceiptAccount` remains MVP+1 or is promoted into MVP-core for ops/audit reasons.
 3. Confirm `max_histogram_entries_per_batch` launch value and governance tuning rules.
 4. Confirm server batch construction policy (`target_batch_size = 20`) and whether adaptive sizing is allowed under constraints.
+
+---
+
+## 14) Updated End-to-End Implementation Checklist
+
+Use this checklist as the execution tracker for implementing the full unified plan.
+
+### 0) Governance decisions (must lock first)
+
+- [x] Resolve and freeze all Section 13 decision points with lean MVP choices.
+- [ ] Publish error-code map and operator runbook for settlement failures.
+
+### 1) On-chain account model (MVP-core)
+
+- [ ] Implement and test account layouts + PDA derivations for:
+  - [ ] CharacterRootAccount
+  - [ ] CharacterStatsAccount
+  - [ ] CharacterWorldProgressAccount
+  - [ ] CharacterZoneProgressPageAccount
+  - [ ] CharacterLoadoutAccount
+  - [ ] ZoneRegistryAccount
+  - [ ] ZoneEnemySetAccount
+  - [ ] EnemyArchetypeRegistryAccount
+  - [ ] ProgramConfigAccount
+  - [ ] CharacterSettlementBatchCursorAccount
+- [ ] Initialize cursor defaults during character creation:
+  - [ ] `last_committed_end_nonce = 0`
+  - [ ] `last_committed_state_hash = genesis_state_hash(character_root)`
+  - [ ] `last_committed_batch_id = 0`
+
+### 2) Instruction + canonical payload contract
+
+- [ ] Implement `ApplyBattleSettlementBatchV1` instruction data layout exactly as frozen.
+- [ ] Implement canonical serialization for payload hashing/signature verification.
+- [ ] Recompute and equality-check `batch_hash` on-chain for every submission.
+- [ ] Enforce signature-domain separation (`program_id`, `cluster_id`, `character_root_pubkey`).
+
+### 3) Attestation and trust checks
+
+- [ ] Verify ed25519 server signature with Solana native flow.
+- [ ] Accept only `trusted_server_signers` from `ProgramConfigAccount`.
+- [ ] Enforce attestation validity window and expiry.
+- [ ] Enforce `settlement_paused` behavior per locked policy.
+
+### 4) Batch validation sequence (instruction core)
+
+- [ ] Implement derivation/ownership checks.
+- [ ] Implement policy checks (`max_battles_per_batch`, `max_histogram_entries_per_batch`).
+- [ ] Implement continuity checks (`start_nonce`, `start_state_hash`, `batch_id`, nonce range).
+- [ ] Implement histogram integrity checks (sum/count, non-zero counts, duplicates forbidden).
+- [ ] Implement world eligibility checks for all referenced zones.
+- [ ] Implement zone/enemy legality checks against registry mapping.
+- [ ] Implement reward cap checks using registry-bound policy.
+- [ ] Implement optional loadout revision check.
+- [ ] Apply progression transitions with monotonic rules.
+- [ ] Persist cursor updates.
+
+### 5) Account access wiring + compute envelope
+
+- [ ] Enforce required account set and mutability constraints in instruction account validation.
+- [ ] Support multi-page zone progress account access for large batches.
+- [ ] Benchmark compute for worst-case allowed batch (`battle_count=32`, histogram entries=64).
+
+### 6) Server batch construction + submission orchestration
+
+- [ ] Implement contiguous batch construction target (`target_batch_size=20`).
+- [ ] Enforce strict oldest-first submission continuity.
+- [ ] Store batch metadata for retries/reconciliation and support tooling.
+
+### 7) Testing + verification gates
+
+- [ ] Add deterministic success/failure vectors for every invariant.
+- [ ] Add replay/out-of-order test matrix across sequential batches.
+- [ ] Add boundary tests for max-size payloads and arithmetic behavior.
+- [ ] Add signature-domain replay tests (wrong cluster/program/character root).
+
+### 8) MVP+1 optional
+
+- [ ] Decide and implement `BattleSettlementBatchReceiptAccount` if promoted.
+- [ ] Add receipt indexing/dispute support tooling.
+
+### 9) Explicitly deferred
+
+- [ ] Inventory/drop settlement domains.
+- [ ] On-chain learning persistence extensions.
+- [ ] Persistent enemy instance domains.
+
+---
+
+## 15) Section 13 Decision Locks (Lean MVP Defaults)
+
+These decisions are now **locked for MVP** to unblock implementation.
+
+### 15.1 Product & trust boundaries (locks)
+
+1. **Dispute/remediation path:** no on-chain dispute flow in MVP; disputes are handled off-chain by support + ops replay tooling.
+2. **Signer model:** single trusted server signer key in `trusted_server_signers` at launch (array size may expand later without schema break).
+3. **Paused behavior:** when `settlement_paused = true`, all player settlement submissions are blocked; no admin bypass path in MVP.
+4. **Attestation validity window:** default `attestation_expiry_slot - attestation_slot = 150` slots.
+
+### 15.2 Batch identity, ordering, replay semantics (locks)
+
+1. `batch_id` is strictly monotonic per character and never resets in MVP.
+2. `genesis_state_hash(character_root)` is `sha256(character_root_pubkey || character_id || 0u64_nonce || 0u64_batch_id)` with canonical little-endian integer encoding.
+3. Deterministic continuity error buckets are frozen: nonce gap, state-hash mismatch, batch-id gap, nonce-range mismatch.
+4. Backlog submission is strict oldest-first only; no skipping or parallelized commit lanes.
+
+### 15.3 Payload canonicalization & signature domain (locks)
+
+1. Canonical serialization is strict field-order Borsh-compatible encoding for all section 6.2 fields.
+2. `cluster_id` is an explicit `u8` enum in signed domain (`1=localnet`, `2=devnet`, `3=testnet`, `4=mainnet-beta`).
+3. Compatibility strategy: new layouts require new `signature_scheme` discriminant and/or new instruction version; no silent reinterpretation.
+4. `batch_hash` is always recomputed on-chain and must exactly match payload-provided hash.
+
+### 15.4 World progression semantics (locks)
+
+1. `locked -> cleared` is globally forbidden in MVP (no zone-level exceptions at launch).
+2. If histogram-implied progression conflicts with `zone_progress_delta`, `zone_progress_delta` is canonical and conflicts fail validation.
+3. `zone_id -> page_index_u16` mapping is `page_index = zone_id / 256` (integer division).
+4. If summary and page data are inconsistent at validation time, fail settlement (no repair path in instruction).
+
+### 15.5 Reward and balance guardrails (locks)
+
+1. `exp_cap_per_encounter(enemy_archetype_id)` is read directly from `EnemyArchetypeRegistryAccount.exp_reward_base` for MVP.
+2. EXP math uses `u128` intermediates; overflow during intermediate math is rejection, not clamp.
+3. Zero-EXP non-empty batches are valid in MVP.
+4. MVP level-up side effects are limited to level/exp/stat recalculation domains only; inventory/unlocks/learning side effects are deferred.
+
+### 15.6 Optional components to lock now (locks)
+
+1. `optional_loadout_revision` remains optional in MVP policy.
+2. `BattleSettlementBatchReceiptAccount` remains MVP+1 (not MVP-core).
+3. Launch `max_histogram_entries_per_batch = 64`; governance can lower/raise through program config update.
+4. Server batch construction targets 20 battles but may adapt size as long as on-chain constraints are met.

--- a/lib/solana/settlementBatchValidation.ts
+++ b/lib/solana/settlementBatchValidation.ts
@@ -1,0 +1,225 @@
+import {
+  ApplyBattleSettlementBatchV1Payload,
+  SettlementValidationContext,
+  SettlementApplyResult,
+  ZoneState,
+} from "../../types/settlement";
+
+const XP_PER_LEVEL = 100;
+
+function assertCondition(condition: boolean, code: string, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`${code}: ${message}`);
+  }
+}
+
+function validateZoneTransition(current: ZoneState, next: ZoneState, allowDirectLockedToCleared: boolean): void {
+  if (next < current) {
+    throw new Error("ERR_ZONE_STATE_DOWNGRADE: zone state cannot downgrade");
+  }
+
+  if (current === 0 && next === 2 && !allowDirectLockedToCleared) {
+    throw new Error("ERR_ZONE_INVALID_TRANSITION: locked->cleared is forbidden by policy");
+  }
+}
+
+function recomputeWorldSummary(zoneStates: Map<number, ZoneState>): {
+  highestMainZoneUnlocked: number;
+  highestMainZoneCleared: number;
+} {
+  let highestMainZoneUnlocked = 0;
+  let highestMainZoneCleared = 0;
+
+  for (const [zoneId, state] of zoneStates.entries()) {
+    if (state >= 1) {
+      highestMainZoneUnlocked = Math.max(highestMainZoneUnlocked, zoneId);
+    }
+    if (state >= 2) {
+      highestMainZoneCleared = Math.max(highestMainZoneCleared, zoneId);
+    }
+  }
+
+  return { highestMainZoneUnlocked, highestMainZoneCleared };
+}
+
+export function applyBattleSettlementBatchV1(
+  payload: ApplyBattleSettlementBatchV1Payload,
+  context: SettlementValidationContext,
+): SettlementApplyResult {
+  const {
+    programConfig,
+    currentSlot,
+    playerAuthority,
+    characterRoot,
+    characterStats,
+    characterWorldProgress,
+    zoneStates,
+    loadout,
+    cursor,
+    serverSigner,
+    zoneRegistry,
+    zoneEnemySet,
+    enemyArchetypes,
+  } = context;
+
+  // 1) Derivation and ownership (approximated in off-chain TS model).
+  assertCondition(characterRoot.authority === playerAuthority, "ERR_UNAUTHORIZED", "player is not character authority");
+  assertCondition(characterRoot.characterId === payload.characterId, "ERR_CHARACTER_MISMATCH", "character id mismatch");
+
+  // 2) Program config checks.
+  assertCondition(!programConfig.settlementPaused, "ERR_SETTLEMENT_PAUSED", "settlement is paused");
+  assertCondition(
+    programConfig.trustedServerSigners.includes(serverSigner),
+    "ERR_UNTRUSTED_SERVER_SIGNER",
+    "server signer is not trusted",
+  );
+  assertCondition(payload.attestationExpirySlot >= currentSlot, "ERR_ATTESTATION_EXPIRED", "attestation is expired");
+  assertCondition(
+    payload.battleCount <= programConfig.maxBattlesPerBatch,
+    "ERR_BATCH_TOO_LARGE",
+    "battle count exceeds max policy",
+  );
+  assertCondition(
+    payload.encounterHistogram.length <= programConfig.maxHistogramEntriesPerBatch,
+    "ERR_HISTOGRAM_TOO_LARGE",
+    "histogram entry count exceeds max policy",
+  );
+
+  // 3) Batch continuity checks.
+  assertCondition(
+    payload.startNonce === cursor.lastCommittedEndNonce + 1,
+    "ERR_NONCE_GAP",
+    "start nonce must match cursor continuity",
+  );
+  assertCondition(
+    payload.startStateHash === cursor.lastCommittedStateHash,
+    "ERR_STATE_HASH_GAP",
+    "start state hash must match cursor continuity",
+  );
+  assertCondition(payload.batchId === cursor.lastCommittedBatchId + 1, "ERR_BATCH_ID_GAP", "batch id must be monotonic");
+  assertCondition(payload.endNonce >= payload.startNonce, "ERR_NONCE_ORDER", "end nonce must be >= start nonce");
+  assertCondition(
+    payload.battleCount === payload.endNonce - payload.startNonce + 1,
+    "ERR_BATTLE_COUNT_NONCE_MISMATCH",
+    "battle count must equal nonce range",
+  );
+
+  // 4) Histogram integrity checks.
+  const keySet = new Set<string>();
+  let histogramBattleTotal = 0;
+
+  for (const entry of payload.encounterHistogram) {
+    assertCondition(entry.count > 0, "ERR_HISTOGRAM_ZERO_COUNT", "histogram entry count must be > 0");
+
+    const key = `${entry.zoneId}:${entry.enemyArchetypeId}`;
+    assertCondition(!keySet.has(key), "ERR_HISTOGRAM_DUPLICATE", "duplicate zone/enemy pair in histogram");
+    keySet.add(key);
+
+    histogramBattleTotal += entry.count;
+  }
+
+  assertCondition(
+    histogramBattleTotal === payload.battleCount,
+    "ERR_HISTOGRAM_COUNT_MISMATCH",
+    "histogram battle sum must equal battle_count",
+  );
+
+  const zoneDeltaMap = new Map<number, ZoneState>();
+  for (const delta of payload.zoneProgressDelta) {
+    assertCondition(zoneRegistry.has(delta.zoneId), "ERR_UNKNOWN_ZONE_DELTA", "zone delta references unknown zone");
+    assertCondition(!zoneDeltaMap.has(delta.zoneId), "ERR_DUPLICATE_ZONE_DELTA", "duplicate zone progress delta zone id");
+    zoneDeltaMap.set(delta.zoneId, delta.newState);
+  }
+
+  // 5-7) World eligibility, zone/enemy legality, reward bounds.
+  let maxAllowedExp = 0;
+  for (const entry of payload.encounterHistogram) {
+    const zoneMeta = zoneRegistry.get(entry.zoneId);
+    assertCondition(Boolean(zoneMeta), "ERR_UNKNOWN_ZONE", "histogram references unknown zone");
+
+    const currentState = zoneStates.get(entry.zoneId) ?? 0;
+    const deltaState = zoneDeltaMap.get(entry.zoneId);
+    const projectedState = deltaState ?? currentState;
+
+    // referenced zone must be currently unlocked, or become unlocked/cleared in same batch.
+    assertCondition(
+      projectedState >= 1,
+      "ERR_LOCKED_ZONE_REFERENCE",
+      "batch references zone that is not unlocked for this character",
+    );
+
+    const allowedEnemies = zoneEnemySet.get(entry.zoneId);
+    assertCondition(Boolean(allowedEnemies), "ERR_ZONE_ENEMY_SET_MISSING", "zone enemy set is missing");
+    assertCondition(
+      allowedEnemies?.has(entry.enemyArchetypeId) ?? false,
+      "ERR_ILLEGAL_ZONE_ENEMY_PAIR",
+      "enemy archetype is not legal for referenced zone",
+    );
+
+    const enemy = enemyArchetypes.get(entry.enemyArchetypeId);
+    assertCondition(Boolean(enemy), "ERR_UNKNOWN_ENEMY_ARCHETYPE", "enemy archetype registry entry missing");
+    maxAllowedExp += entry.count * (enemy?.expCapPerEncounter ?? 0);
+  }
+
+  assertCondition(payload.expDelta <= maxAllowedExp, "ERR_EXP_OVER_CAP", "exp delta exceeds registry-derived cap");
+
+  // 8) Optional loadout consistency.
+  if (payload.optionalLoadoutRevision !== undefined) {
+    assertCondition(Boolean(loadout), "ERR_LOADOUT_REQUIRED", "loadout account required when loadout revision is provided");
+    assertCondition(
+      loadout?.loadoutRevision === payload.optionalLoadoutRevision,
+      "ERR_LOADOUT_REVISION_MISMATCH",
+      "loadout revision mismatch",
+    );
+  }
+
+  // 9) Apply progression transitions.
+  const nextZoneStates = new Map(zoneStates);
+  for (const [zoneId, nextState] of zoneDeltaMap.entries()) {
+    const zoneMeta = zoneRegistry.get(zoneId);
+    assertCondition(Boolean(zoneMeta), "ERR_UNKNOWN_ZONE_DELTA", "zone delta references unknown zone");
+
+    const currentState = nextZoneStates.get(zoneId) ?? 0;
+    validateZoneTransition(currentState, nextState, Boolean(zoneMeta?.allowDirectLockedToCleared));
+    nextZoneStates.set(zoneId, nextState);
+  }
+
+  let nextExp = characterRoot.exp + payload.expDelta;
+  let nextLevel = characterRoot.level;
+  let leveledUp = false;
+
+  while (nextExp >= XP_PER_LEVEL) {
+    nextExp -= XP_PER_LEVEL;
+    nextLevel += 1;
+    leveledUp = true;
+  }
+
+  const recomputedSummary = recomputeWorldSummary(nextZoneStates);
+
+  // 10) Persist batch cursor.
+  return {
+    characterRoot: {
+      ...characterRoot,
+      level: nextLevel,
+      exp: nextExp,
+    },
+    characterStats: {
+      ...characterStats,
+      lastRecalcSlot: leveledUp ? currentSlot : characterStats.lastRecalcSlot,
+    },
+    characterWorldProgress: {
+      ...characterWorldProgress,
+      highestMainZoneUnlocked: recomputedSummary.highestMainZoneUnlocked,
+      highestMainZoneCleared: recomputedSummary.highestMainZoneCleared,
+      updatedAtSlot: currentSlot,
+    },
+    zoneStates: nextZoneStates,
+    cursor: {
+      ...cursor,
+      lastCommittedEndNonce: payload.endNonce,
+      lastCommittedStateHash: payload.endStateHash,
+      lastCommittedBatchId: payload.batchId,
+      updatedAtSlot: currentSlot,
+    },
+  };
+}

--- a/tests/settlementBatchValidation.test.ts
+++ b/tests/settlementBatchValidation.test.ts
@@ -1,0 +1,135 @@
+import { applyBattleSettlementBatchV1 } from "../lib/solana/settlementBatchValidation";
+import { ApplyBattleSettlementBatchV1Payload, SettlementValidationContext, ZoneState } from "../types/settlement";
+
+function buildContext(overrides?: Partial<SettlementValidationContext>): SettlementValidationContext {
+  const baseZoneStates = new Map<number, ZoneState>([
+    [1, 1],
+    [2, 0],
+  ]);
+
+  return {
+    currentSlot: 10_000,
+    playerAuthority: "player-1",
+    serverSigner: "server-1",
+    characterRoot: {
+      characterId: "char-1",
+      authority: "player-1",
+      level: 1,
+      exp: 90,
+    },
+    characterStats: {
+      lastRecalcSlot: 9_000,
+    },
+    characterWorldProgress: {
+      highestMainZoneUnlocked: 1,
+      highestMainZoneCleared: 0,
+      updatedAtSlot: 9_000,
+    },
+    zoneStates: baseZoneStates,
+    loadout: {
+      loadoutRevision: 7,
+    },
+    cursor: {
+      lastCommittedEndNonce: 0,
+      lastCommittedStateHash: "genesis",
+      lastCommittedBatchId: 0,
+      updatedAtSlot: 9_000,
+    },
+    programConfig: {
+      settlementPaused: false,
+      maxBattlesPerBatch: 32,
+      maxHistogramEntriesPerBatch: 64,
+      trustedServerSigners: ["server-1"],
+    },
+    zoneRegistry: new Map([
+      [1, { zoneId: 1 }],
+      [2, { zoneId: 2 }],
+    ]),
+    zoneEnemySet: new Map([
+      [1, new Set([10])],
+      [2, new Set([20])],
+    ]),
+    enemyArchetypes: new Map([
+      [10, { enemyArchetypeId: 10, expCapPerEncounter: 30 }],
+      [20, { enemyArchetypeId: 20, expCapPerEncounter: 50 }],
+    ]),
+    ...overrides,
+  };
+}
+
+function buildPayload(overrides?: Partial<ApplyBattleSettlementBatchV1Payload>): ApplyBattleSettlementBatchV1Payload {
+  return {
+    characterId: "char-1",
+    batchId: 1,
+    startNonce: 1,
+    endNonce: 2,
+    battleCount: 2,
+    startStateHash: "genesis",
+    endStateHash: "hash-1",
+    expDelta: 60,
+    zoneProgressDelta: [{ zoneId: 2, newState: 1 }],
+    encounterHistogram: [
+      { zoneId: 1, enemyArchetypeId: 10, count: 1 },
+      { zoneId: 2, enemyArchetypeId: 20, count: 1 },
+    ],
+    optionalLoadoutRevision: 7,
+    batchHash: "batch-hash",
+    attestationSlot: 9_995,
+    attestationExpirySlot: 10_100,
+    signatureScheme: 0,
+    ...overrides,
+  };
+}
+
+describe("applyBattleSettlementBatchV1", () => {
+  it("applies a valid batch and updates cursor/state", () => {
+    const context = buildContext();
+    const payload = buildPayload();
+
+    const result = applyBattleSettlementBatchV1(payload, context);
+
+    expect(result.cursor.lastCommittedEndNonce).toBe(2);
+    expect(result.cursor.lastCommittedBatchId).toBe(1);
+    expect(result.cursor.lastCommittedStateHash).toBe("hash-1");
+    expect(result.characterRoot.level).toBe(2);
+    expect(result.characterRoot.exp).toBe(50);
+    expect(result.characterStats.lastRecalcSlot).toBe(10_000);
+    expect(result.zoneStates.get(2)).toBe(1);
+    expect(result.characterWorldProgress.highestMainZoneUnlocked).toBe(2);
+  });
+
+  it("rejects duplicate histogram pairs", () => {
+    const context = buildContext();
+    const payload = buildPayload({
+      encounterHistogram: [
+        { zoneId: 1, enemyArchetypeId: 10, count: 1 },
+        { zoneId: 1, enemyArchetypeId: 10, count: 1 },
+      ],
+    });
+
+    expect(() => applyBattleSettlementBatchV1(payload, context)).toThrow(/ERR_HISTOGRAM_DUPLICATE/);
+  });
+
+  it("rejects exp inflation beyond histogram-derived cap", () => {
+    const context = buildContext();
+    const payload = buildPayload({ expDelta: 1000 });
+
+    expect(() => applyBattleSettlementBatchV1(payload, context)).toThrow(/ERR_EXP_OVER_CAP/);
+  });
+
+  it("rejects out-of-order batch submission", () => {
+    const context = buildContext();
+    const payload = buildPayload({ startNonce: 2, endNonce: 3 });
+
+    expect(() => applyBattleSettlementBatchV1(payload, context)).toThrow(/ERR_NONCE_GAP/);
+  });
+
+  it("rejects locked->cleared when zone policy does not allow it", () => {
+    const context = buildContext();
+    const payload = buildPayload({
+      zoneProgressDelta: [{ zoneId: 2, newState: 2 }],
+    });
+
+    expect(() => applyBattleSettlementBatchV1(payload, context)).toThrow(/ERR_ZONE_INVALID_TRANSITION/);
+  });
+});

--- a/types/settlement.ts
+++ b/types/settlement.ts
@@ -1,0 +1,99 @@
+export type ZoneState = 0 | 1 | 2;
+
+export interface EncounterCountEntry {
+  zoneId: number;
+  enemyArchetypeId: number;
+  count: number;
+}
+
+export interface ZoneProgressDeltaEntry {
+  zoneId: number;
+  newState: ZoneState;
+}
+
+export interface ApplyBattleSettlementBatchV1Payload {
+  characterId: string;
+  batchId: number;
+  startNonce: number;
+  endNonce: number;
+  battleCount: number;
+  startStateHash: string;
+  endStateHash: string;
+  expDelta: number;
+  zoneProgressDelta: ZoneProgressDeltaEntry[];
+  encounterHistogram: EncounterCountEntry[];
+  optionalLoadoutRevision?: number;
+  batchHash: string;
+  attestationSlot: number;
+  attestationExpirySlot: number;
+  signatureScheme: 0;
+}
+
+export interface ProgramConfigState {
+  settlementPaused: boolean;
+  maxBattlesPerBatch: number;
+  maxHistogramEntriesPerBatch: number;
+  trustedServerSigners: string[];
+}
+
+export interface CharacterRootState {
+  characterId: string;
+  authority: string;
+  level: number;
+  exp: number;
+}
+
+export interface CharacterStatsState {
+  lastRecalcSlot: number;
+}
+
+export interface CharacterLoadoutState {
+  loadoutRevision: number;
+}
+
+export interface CharacterWorldProgressState {
+  highestMainZoneUnlocked: number;
+  highestMainZoneCleared: number;
+  updatedAtSlot: number;
+}
+
+export interface CharacterSettlementBatchCursorState {
+  lastCommittedEndNonce: number;
+  lastCommittedStateHash: string;
+  lastCommittedBatchId: number;
+  updatedAtSlot: number;
+}
+
+export interface ZoneRegistryEntry {
+  zoneId: number;
+  allowDirectLockedToCleared?: boolean;
+}
+
+export interface EnemyArchetypeRegistryEntry {
+  enemyArchetypeId: number;
+  expCapPerEncounter: number;
+}
+
+export interface SettlementValidationContext {
+  currentSlot: number;
+  playerAuthority: string;
+  serverSigner: string;
+  characterRoot: CharacterRootState;
+  characterStats: CharacterStatsState;
+  characterWorldProgress: CharacterWorldProgressState;
+  zoneStates: Map<number, ZoneState>;
+  loadout?: CharacterLoadoutState;
+  cursor: CharacterSettlementBatchCursorState;
+  programConfig: ProgramConfigState;
+  zoneRegistry: Map<number, ZoneRegistryEntry>;
+  zoneEnemySet: Map<number, Set<number>>;
+  enemyArchetypes: Map<number, EnemyArchetypeRegistryEntry>;
+}
+
+export interface SettlementApplyResult {
+  characterRoot: CharacterRootState;
+  characterStats: CharacterStatsState;
+  characterWorldProgress: CharacterWorldProgressState;
+  zoneStates: Map<number, ZoneState>;
+  cursor: CharacterSettlementBatchCursorState;
+}


### PR DESCRIPTION
### Motivation

- Provide an executable off-chain TypeScript model of the unified battle settlement validation to exercise and lock invariants before on-chain implementation.
- Capture and enforce the MVP decision locks for batch ordering, payload canonicalization, progression semantics, and reward caps in code and documentation.
- Offer a concrete test harness for replay, boundary and policy checks so server tooling and on-chain logic can be aligned.

### Description

- Add `types/settlement.ts` which defines payload, context and state types including `ZoneState`, `ApplyBattleSettlementBatchV1Payload`, and `SettlementValidationContext`.
- Implement `applyBattleSettlementBatchV1` in `lib/solana/settlementBatchValidation.ts` which performs derivation/ownership checks, program-config checks, batch continuity, histogram integrity, zone/enemy legality, reward cap checks, optional loadout validation, progression transition validation, XP/leveling, and cursor/state updates.
- Add unit tests in `tests/settlementBatchValidation.test.ts` exercising a valid batch and failure vectors for duplicate histogram entries, EXP over-cap, out-of-order submission, and forbidden locked->cleared transitions.
- Update `docs/solana-battle-outcome-validation-mvp-unified-plan.md` with an updated end-to-end implementation checklist and explicit Section 13 decision locks for the lean MVP.

### Testing

- Ran unit tests with the repository test runner (`yarn test` / `npm test`) executing `tests/settlementBatchValidation.test.ts`, and all tests passed.
- The test suite covers applying a valid batch and assertions for cursor/state updates executed successfully.
- Failure vectors validated by tests include duplicate histogram pairs, EXP inflation beyond registry cap, nonce continuity gaps, and forbidden locked->cleared transitions, and each failure test passed (i.e., correctly threw the expected error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8bc02461c8329b8819f227b1214d6)