### PR TITLE
docs: add Solana settlement trust model to SSOT

### DIFF
--- a/docs/SSOT.md
+++ b/docs/SSOT.md
@@ -57,7 +57,35 @@ The server is the **only authority** for outcomes.
 
 ---
 
-## 2.3 Vertical Slice Development
+## 2.3 Solana Settlement Trust Model (MVP)
+
+For Solana settlement in MVP, trust boundaries are explicitly split:
+
+- The **server remains authoritative** for battle simulation details.
+- The **on-chain program enforces bounded legality/economic constraints**.
+
+Security objective:
+
+- If the server is compromised, the maximum adversarial impact must be limited to **diligent-player-equivalent progression**.
+
+Explicit goals for MVP settlement validation:
+
+- Prevent reward inflation.
+- Prevent impossible progression jumps.
+- Prevent replay and out-of-order settlement.
+- Prevent impossible battle throughput.
+
+Explicit non-goal for MVP:
+
+- **No cryptographic proof of exact per-turn historical truth**.
+
+Canonical implementation details for this trust model are defined in:
+
+- `/docs/solana-battle-outcome-validation-mvp-unified-plan.md`
+
+---
+
+## 2.4 Vertical Slice Development
 
 Development follows **Vertical Slice Expansion**:
 


### PR DESCRIPTION
### Motivation

- Introduce an explicit Solana settlement trust model into the single source of truth to document MVP trust boundaries and product-level security goals.
- Record which responsibilities remain server-side and which are enforced on-chain to guide implementation and audits.
- Call out an explicit non-goal to set expectations about cryptographic per-turn proofs for the MVP.

### Description

- Added a new `2.3 Solana Settlement Trust Model (MVP)` section to `docs/SSOT.md` that states the server remains authoritative for simulation details and the on-chain program enforces bounded legality/economic constraints.
- Added a security objective that a compromised server can at most effect ``diligent-player-equivalent progression`` and enumerated explicit MVP goals to prevent reward inflation, impossible progression jumps, replay/out-of-order settlement, and impossible battle throughput.
- Added an explicit non-goal stating there is ``no cryptographic proof of exact per-turn historical truth`` in the MVP and cross-linked to `/docs/solana-battle-outcome-validation-mvp-unified-plan.md` as the canonical implementation detail.
- Renumbered the following section from `2.3` to `2.4` to accommodate the new content and committed the change.

### Testing

- Ran repository checks with `rg` to find relevant docs and results succeeded.
- Inspected the updated file slice with `nl -ba docs/SSOT.md | sed -n '40,130p'` and the expected section text appeared successfully.
- Verified working tree status with `git status --short` and committed the change with `git commit`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd1ef0d488329a662bf12e47da0a8)